### PR TITLE
fix(gpu_drivers): fix molecule tests for Docker + Vagrant

### DIFF
--- a/ansible/roles/gpu_drivers/molecule/docker/prepare.yml
+++ b/ansible/roles/gpu_drivers/molecule/docker/prepare.yml
@@ -20,3 +20,9 @@
         name: pciutils
         state: present
       when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Install pciutils (Ubuntu)
+      ansible.builtin.apt:
+        name: pciutils
+        state: present
+      when: ansible_facts['os_family'] == 'Debian'

--- a/ansible/roles/gpu_drivers/tasks/initramfs.yml
+++ b/ansible/roles/gpu_drivers/tasks/initramfs.yml
@@ -20,8 +20,8 @@
   ansible.builtin.set_fact:
     gpu_drivers_initramfs_tool: >-
       {{ 'mkinitcpio' if ansible_facts['os_family'] == 'Archlinux'
-         else ('dracut' if (_gpu_drivers_dracut_check is not skipped
-                           and _gpu_drivers_dracut_check.rc == 0)
+         else ('dracut' if (gpu_drivers_dracut_check is not skipped
+                           and gpu_drivers_dracut_check.rc == 0)
          else 'initramfs-tools') }}
   when: gpu_drivers_manage_initramfs
   tags: ['gpu', 'nvidia']


### PR DESCRIPTION
## Summary

- Fix undefined variable \`_gpu_drivers_dracut_check\` in \`tasks/initramfs.yml\` — caused Ansible error on Ubuntu/Debian with default \`gpu_drivers_manage_initramfs: true\`
- Add pciutils install for Ubuntu in \`molecule/docker/prepare.yml\` — prepare was only handling Arch

## Test plan

- [ ] Docker test passes (Arch + Ubuntu platforms)
- [ ] Vagrant Arch test passes
- [ ] Vagrant Ubuntu test passes
- [ ] All idempotence checks pass (second run = zero changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)