### PR TITLE
fix(sysctl): fix molecule tests for Docker + Vagrant

### DIFF
--- a/ansible/roles/sysctl/handlers/main.yml
+++ b/ansible/roles/sysctl/handlers/main.yml
@@ -8,5 +8,8 @@
   # --system = читает все /etc/sysctl.d/*.conf (не зависит от init, но применяется
   #            systemd-sysctl.service при boot на Arch/Debian)
   # changed_when: false — изменение репортит template-таск (notify), не handler
+  # when: пропустить в Docker — kernel params read-only (EPERM) даже с privileged:true.
+  #       Tier 2 verify тоже пропускает live-checks в контейнерах.
   ansible.builtin.command: sysctl -e --system
   changed_when: false
+  when: ansible_virtualization_type | default('') != 'docker'

--- a/ansible/roles/sysctl/handlers/main.yml
+++ b/ansible/roles/sysctl/handlers/main.yml
@@ -5,11 +5,12 @@
   listen: "reload sysctl"
   # -e = игнорировать ошибки неизвестных параметров (например kernel.unprivileged_userns_clone
   #      отсутствует на стандартном upstream ядре — distro-agnostic поведение)
-  # --system = читает все /etc/sysctl.d/*.conf (не зависит от init, но применяется
-  #            systemd-sysctl.service при boot на Arch/Debian)
+  # -p = применить ТОЛЬКО наш файл, не --system (который читает все sysctl.d/* по порядку
+  #      и может быть перезаписан файлом, идущим лексикографически после 99-ansible.conf,
+  #      например Ubuntu's 99-sysctl.conf symlink → /etc/sysctl.conf)
   # changed_when: false — изменение репортит template-таск (notify), не handler
   # when: пропустить в Docker — kernel params read-only (EPERM) даже с privileged:true.
   #       Tier 2 verify тоже пропускает live-checks в контейнерах.
-  ansible.builtin.command: sysctl -e --system
+  ansible.builtin.command: sysctl -e -p /etc/sysctl.d/99-ansible.conf
   changed_when: false
   when: ansible_virtualization_type | default('') != 'docker'

--- a/ansible/roles/sysctl/molecule/vagrant/prepare.yml
+++ b/ansible/roles/sysctl/molecule/vagrant/prepare.yml
@@ -1,0 +1,16 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Update pacman package cache (Arch)
+      community.general.pacman:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Update apt cache (Ubuntu)
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_facts['os_family'] == 'Debian'

--- a/ansible/roles/sysctl/templates/sysctl.conf.j2
+++ b/ansible/roles/sysctl/templates/sysctl.conf.j2
@@ -173,9 +173,6 @@ fs.suid_dumpable = {{ sysctl_fs_suid_dumpable }}
 {% if sysctl_custom_params | length > 0 %}
 # ---- Custom parameters ----
 {% for param in sysctl_custom_params %}
-{%   if param.name is not defined or param.value is not defined %}
-{%     raise "sysctl_custom_params entry missing 'name' or 'value': " ~ (param | string) %}
-{%   endif %}
-{{ param.name }} = {{ param.value }}
+{{ param.name | mandatory("sysctl_custom_params[" ~ loop.index0 ~ "] is missing 'name'") }} = {{ param.value | mandatory("sysctl_custom_params[" ~ loop.index0 ~ "] is missing 'value'") }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary

- Fix `sysctl -e --system` handler failing in Docker: add `when: ansible_virtualization_type | default('') != 'docker'` to skip in containers where kernel params are EPERM even with `privileged: true`
- Add `molecule/vagrant/prepare.yml` following project convention for package cache update

## Root cause

The \`-e\` flag on \`sysctl\` only suppresses unknown-key errors (ENOENT), not permission errors (EPERM). In Docker containers, kernel-namespace parameters are read-only regardless of \`privileged: true\`. Handler exited non-zero → converge failed.

The fix mirrors the detection pattern already used in \`shared/verify.yml\` Tier 2 (\`ansible_virtualization_type | default('') == 'docker'\`).

## Test plan

- [ ] Docker: \`molecule test -s docker\` — triggered automatically by this PR
- [ ] Vagrant arch-vm: triggered via \`workflow_dispatch\` on \`molecule.yml\` with \`role_filter=sysctl\`
- [ ] Vagrant ubuntu-base: same dispatch, both platforms run in matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)