### PR TITLE
fix(packages): fix verify.yml — remove vars_files precedence bug

### DIFF
--- a/ansible/roles/packages/molecule/shared/verify.yml
+++ b/ansible/roles/packages/molecule/shared/verify.yml
@@ -3,8 +3,6 @@
   hosts: all
   become: true
   gather_facts: true
-  vars_files:
-    - "../../defaults/main.yml"
 
   tasks:
 
@@ -13,22 +11,22 @@
     - name: Build combined package list (mirrors tasks/main.yml logic)
       ansible.builtin.set_fact:
         packages_verify_expected: >-
-          {{ packages_base
-             + packages_editors
-             + packages_docker
-             + packages_xorg
-             + packages_wm
-             + packages_filemanager
-             + packages_network
-             + packages_media
-             + packages_desktop
-             + packages_graphics
-             + packages_session
-             + packages_terminal
-             + packages_fonts
-             + packages_theming
-             + packages_search
-             + packages_viewers
+          {{ (packages_base | default([]))
+             + (packages_editors | default([]))
+             + (packages_docker | default([]))
+             + (packages_xorg | default([]))
+             + (packages_wm | default([]))
+             + (packages_filemanager | default([]))
+             + (packages_network | default([]))
+             + (packages_media | default([]))
+             + (packages_desktop | default([]))
+             + (packages_graphics | default([]))
+             + (packages_session | default([]))
+             + (packages_terminal | default([]))
+             + (packages_fonts | default([]))
+             + (packages_theming | default([]))
+             + (packages_search | default([]))
+             + (packages_viewers | default([]))
              + (packages_distro[ansible_facts['os_family']] | default([])) }}
 
     # ---- Gather package facts ----
@@ -48,36 +46,6 @@
       loop_control:
         label: "{{ item }}"
 
-    # ---- Verify idempotence hint: no pending actions ----
-
-    - name: Verify package install is idempotent (Arch)
-      community.general.pacman:
-        name: "{{ packages_verify_expected }}"
-        state: present
-      check_mode: true
-      register: packages_verify_idem_arch
-      when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Assert pacman install reports no changes
-      ansible.builtin.assert:
-        that: not packages_verify_idem_arch.changed
-        fail_msg: "pacman would still install packages -- converge was not idempotent"
-      when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Verify package install is idempotent (Debian)
-      ansible.builtin.apt:
-        name: "{{ packages_verify_expected }}"
-        state: present
-      check_mode: true
-      register: packages_verify_idem_deb
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Assert apt install reports no changes
-      ansible.builtin.assert:
-        that: not packages_verify_idem_deb.changed
-        fail_msg: "apt would still install packages -- converge was not idempotent"
-      when: ansible_facts['os_family'] == 'Debian'
-
     # ---- Summary ----
 
     - name: Show verify result
@@ -85,4 +53,4 @@
         msg: >-
           packages verify passed on
           {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}:
-          all {{ packages_verify_expected | length }} packages present and idempotent.
+          all {{ packages_verify_expected | length }} packages present.

--- a/docs/plans/2026-03-01-packages-molecule-fix-design.md
+++ b/docs/plans/2026-03-01-packages-molecule-fix-design.md
@@ -1,0 +1,83 @@
+# packages molecule test fix — Design
+
+**Date:** 2026-03-01
+**Status:** Approved
+**Scope:** Fix molecule tests for `packages` role so all 3 CI environments pass with real package verification (Docker Arch+Ubuntu, Vagrant Arch, Vagrant Ubuntu).
+
+## Context
+
+The `packages` role has molecule tests (docker + vagrant scenarios) written in `00571a3`. The tests currently pass CI — but trivially, without checking anything useful. A static analysis found a critical precedence bug in `verify.yml`.
+
+## Confirmed Bug
+
+### `molecule/shared/verify.yml` — vars_files overrides molecule inventory (CRITICAL)
+
+`verify.yml` loads role defaults via `vars_files`:
+
+```yaml
+vars_files:
+  - "../../defaults/main.yml"
+```
+
+Ansible variable precedence:
+- `vars_files` in a play = **precedence 14**
+- molecule inventory `group_vars` (from `molecule.yml` provisioner) = **precedence 4**
+
+Result: `vars_files` overrides the molecule-configured packages (`packages_base: [git, curl, ...]` etc.) with the role defaults (`packages_base: []`). Additionally, `packages_distro: {}` means the distro-specific list also resolves to `[]`.
+
+Final `packages_verify_expected = []` → the assertion loop is empty → the verify step passes trivially without checking a single installed package.
+
+The converge step is NOT affected (no `vars_files` in `converge.yml`), so packages ARE installed correctly. Only verification is broken.
+
+## Fix
+
+### `molecule/shared/verify.yml`
+
+Two changes:
+
+1. **Remove `vars_files`** — molecule inventory group_vars (precedence 4) are correctly picked up without interference.
+
+2. **Add `| default([])` guards** to every list in `set_fact` — makes verify.yml robust for any scenario where a category variable is not explicitly defined (e.g., the `default` local scenario).
+
+3. **Remove the check_mode idempotence section** — the tasks that run `community.general.pacman` and `ansible.builtin.apt` in `check_mode: true` are redundant. Molecule's built-in `idempotence` step (re-running converge and asserting no changes) already covers this. Removing them simplifies verify.yml and eliminates a potential failure point.
+
+### Resulting verify.yml logic
+
+```
+1. Build packages_verify_expected from molecule inventory vars (no vars_files)
+2. Gather package_facts (manager: auto)
+3. Assert each expected package is in ansible_facts.packages
+4. Print summary
+```
+
+### No other changes
+
+All other files are correct:
+- `docker/molecule.yml` — correct platform config, DNS, image refs
+- `docker/prepare.yml` — correctly updates cache for both Arch (pacman) and Ubuntu (apt)
+- `vagrant/molecule.yml` — correct boxes and provisioner config
+- `vagrant/prepare.yml` — correct (apt update for Ubuntu; Arch install task has `update_cache: true`)
+- `tasks/main.yml` — correct, skip-tags: upgrade prevents pacman -Syu in idempotence
+- `defaults/main.yml` — correct
+
+## Expected packages verified after fix
+
+| Scenario | Arch packages | Ubuntu packages |
+|----------|--------------|-----------------|
+| docker   | git curl htop tmux unzip rsync vim fzf ripgrep jq base-devel | git curl htop tmux unzip rsync vim fzf ripgrep jq build-essential |
+| vagrant  | git curl htop tmux unzip rsync vim fzf jq base-devel | git curl htop tmux unzip rsync vim fzf jq build-essential |
+
+(docker includes `ripgrep`, vagrant does not — by design in existing molecule.yml)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `ansible/roles/packages/molecule/shared/verify.yml` | Remove `vars_files`, add `\| default([])` guards, remove redundant check_mode idempotence section |
+
+## Success Criteria
+
+All 3 CI jobs green in GHA with real package assertions:
+1. `test / packages` (Docker, Arch + Ubuntu platforms)
+2. `test-vagrant / packages / arch-vm`
+3. `test-vagrant / packages / ubuntu-base`

--- a/docs/plans/2026-03-01-packages-molecule-fix.md
+++ b/docs/plans/2026-03-01-packages-molecule-fix.md
@@ -1,0 +1,318 @@
+# packages molecule fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix `verify.yml` so molecule tests actually verify all configured packages are installed, then get all 3 CI environments green (Docker, Vagrant Arch, Vagrant Ubuntu).
+
+**Architecture:** Single file change — remove `vars_files` from `verify.yml` and add `| default([])` guards. The `vars_files` directive has Ansible precedence 14, which silently overrides molecule inventory group_vars (precedence 4), making the expected package list empty and all assertions trivially true.
+
+**Tech Stack:** Ansible, Molecule, community.general.pacman, ansible.builtin.apt, ansible.builtin.package_facts
+
+---
+
+### Task 0: Create git worktree
+
+**Files:** none
+
+**Step 1: Create worktree for the fix branch**
+
+```bash
+cd /Users/umudrakov/Documents/bootstrap
+git worktree add .claude/worktrees/fix/packages-molecule-fix -b fix/packages-molecule-fix
+```
+
+**Step 2: Verify worktree is on the right branch**
+
+```bash
+git -C .claude/worktrees/fix/packages-molecule-fix status
+```
+
+Expected: `On branch fix/packages-molecule-fix`, nothing to commit.
+
+---
+
+### Task 1: Fix verify.yml — remove vars_files, add default guards, drop redundant check_mode section
+
+**Files:**
+- Modify: `ansible/roles/packages/molecule/shared/verify.yml`
+
+**Step 1: Read the current file**
+
+```bash
+cat ansible/roles/packages/molecule/shared/verify.yml
+```
+
+**Step 2: Replace the file with the fixed version**
+
+Write the following content to `ansible/roles/packages/molecule/shared/verify.yml` (in the worktree at `.claude/worktrees/fix/packages-molecule-fix/`):
+
+```yaml
+---
+- name: Verify packages role
+  hosts: all
+  become: true
+  gather_facts: true
+
+  tasks:
+
+    # ---- Build expected package list ----
+
+    - name: Build combined package list (mirrors tasks/main.yml logic)
+      ansible.builtin.set_fact:
+        packages_verify_expected: >-
+          {{ (packages_base | default([]))
+             + (packages_editors | default([]))
+             + (packages_docker | default([]))
+             + (packages_xorg | default([]))
+             + (packages_wm | default([]))
+             + (packages_filemanager | default([]))
+             + (packages_network | default([]))
+             + (packages_media | default([]))
+             + (packages_desktop | default([]))
+             + (packages_graphics | default([]))
+             + (packages_session | default([]))
+             + (packages_terminal | default([]))
+             + (packages_fonts | default([]))
+             + (packages_theming | default([]))
+             + (packages_search | default([]))
+             + (packages_viewers | default([]))
+             + (packages_distro[ansible_facts['os_family']] | default([])) }}
+
+    # ---- Gather package facts ----
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    # ---- Assert all expected packages are installed ----
+
+    - name: Assert each expected package is installed
+      ansible.builtin.assert:
+        that: "item in ansible_facts.packages"
+        fail_msg: "Package '{{ item }}' not found in installed packages"
+        quiet: true
+      loop: "{{ packages_verify_expected }}"
+      loop_control:
+        label: "{{ item }}"
+
+    # ---- Summary ----
+
+    - name: Show verify result
+      ansible.builtin.debug:
+        msg: >-
+          packages verify passed on
+          {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}:
+          all {{ packages_verify_expected | length }} packages present.
+```
+
+**Step 3: Verify the diff looks correct**
+
+```bash
+cd .claude/worktrees/fix/packages-molecule-fix
+git diff ansible/roles/packages/molecule/shared/verify.yml
+```
+
+Expected diff:
+- Line removed: `vars_files:`
+- Line removed: `  - "../../defaults/main.yml"`
+- Each list entry in set_fact wrapped with `| default([])`
+- Entire idempotence hint section removed (two `community.general.pacman`/`ansible.builtin.apt` check_mode tasks + two assert tasks)
+- Summary message simplified (removed "and idempotent" text)
+
+**Step 4: Run ansible-lint on the changed file**
+
+```bash
+cd .claude/worktrees/fix/packages-molecule-fix
+ansible-lint ansible/roles/packages/molecule/shared/verify.yml
+```
+
+Expected: no violations. Fix any lint warnings before proceeding.
+
+**Step 5: Run molecule syntax check**
+
+```bash
+cd .claude/worktrees/fix/packages-molecule-fix/ansible/roles/packages
+molecule syntax -s docker
+```
+
+Expected: `INFO     Sanity checks: 'docker'` with no errors.
+
+**Step 6: Commit**
+
+```bash
+cd .claude/worktrees/fix/packages-molecule-fix
+git add ansible/roles/packages/molecule/shared/verify.yml
+git commit -m "fix(packages): fix verify.yml — remove vars_files precedence bug, add default guards
+
+vars_files (precedence 14) was silently overriding molecule inventory group_vars
+(precedence 4), resulting in packages_verify_expected = [] and all assertions
+being trivially true. Remove vars_files and use | default([]) guards instead.
+Also remove redundant check_mode idempotence section — molecule's built-in
+idempotence step already covers this.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Push branch and open PR
+
+**Files:** none
+
+**Step 1: Push branch to origin**
+
+```bash
+cd .claude/worktrees/fix/packages-molecule-fix
+git push -u origin fix/packages-molecule-fix
+```
+
+**Step 2: Open PR**
+
+```bash
+gh pr create \
+  --title "fix(packages): fix verify.yml — remove vars_files precedence bug" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `verify.yml` loaded `defaults/main.yml` via `vars_files` (Ansible precedence 14), silently overriding molecule inventory `group_vars` (precedence 4)
+- Result: `packages_verify_expected = []` → empty assertion loop → tests passed trivially without checking any package
+- Fix: remove `vars_files`, add `| default([])` guards so molecule inventory variables are correctly used
+- Also removed redundant `check_mode` idempotence tasks — molecule's built-in `idempotence` step already covers this
+
+## Packages now verified
+
+| Scenario | Arch | Ubuntu |
+|----------|------|--------|
+| docker | git curl htop tmux unzip rsync vim fzf ripgrep jq base-devel | git curl htop tmux unzip rsync vim fzf ripgrep jq build-essential |
+| vagrant | git curl htop tmux unzip rsync vim fzf jq base-devel | git curl htop tmux unzip rsync vim fzf jq build-essential |
+
+## Test plan
+- [ ] `test / packages` (Docker — Arch + Ubuntu)
+- [ ] `test-vagrant / packages / arch-vm`
+- [ ] `test-vagrant / packages / ubuntu-base`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 3: Record the PR URL**
+
+```bash
+gh pr view --json url -q .url
+```
+
+Save the URL for monitoring.
+
+---
+
+### Task 3: Monitor CI and fix failures
+
+**Files:** depends on failures
+
+**Step 1: Watch CI status**
+
+```bash
+gh pr checks --watch
+```
+
+Wait for all 3 jobs to complete:
+- `test / packages`
+- `test-vagrant / packages / arch-vm`
+- `test-vagrant / packages / ubuntu-base`
+
+**Step 2: If all green → skip to Task 4**
+
+**Step 3: If any job fails → read the logs**
+
+```bash
+gh run list --branch fix/packages-molecule-fix --limit 5
+gh run view <run-id> --log-failed
+```
+
+**Step 4: Triage failure patterns**
+
+Common failure patterns and fixes:
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `Package 'X' not found in installed packages` | Package name differs between Arch/Ubuntu | Remove package from shared list or add to distro-specific dict |
+| `pacman: error` during converge | Stale mirror or missing package | Update prepare.yml to refresh cache, or remove bad package |
+| `apt: error` during converge | Package not available in Ubuntu 24.04 | Add to packages_distro dict (Arch-only) or remove |
+| Idempotence failure (converge reports changed on 2nd run) | Package manager reports change for already-installed package | Investigate module behavior; may need to add `--needed` flag or update_cache guard |
+| `fzf` or `ripgrep` not in Ubuntu | Package not in ubuntu-base container | Remove from test list or add fallback |
+
+**Step 5: Apply fix, commit, push**
+
+```bash
+cd .claude/worktrees/fix/packages-molecule-fix
+# ... make fix ...
+git add <files>
+git commit -m "fix(packages): <description>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push
+```
+
+CI re-runs automatically on push.
+
+**Step 6: Repeat Steps 1-5 until all 3 jobs are green**
+
+---
+
+### Task 4: Merge PR and clean up
+
+**Files:** none
+
+**Step 1: Verify all CI checks are green**
+
+```bash
+gh pr checks
+```
+
+All checks must show ✓ before merging.
+
+**Step 2: Squash merge the PR**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+**Step 3: Pull master in main worktree**
+
+```bash
+cd /Users/umudrakov/Documents/bootstrap
+git pull
+```
+
+**Step 4: Remove the worktree**
+
+```bash
+git worktree remove .claude/worktrees/fix/packages-molecule-fix
+```
+
+**Step 5: Verify worktree is gone**
+
+```bash
+git worktree list
+```
+
+Expected: only the main worktree listed.
+
+**Step 6: Move design and plan docs to done/**
+
+```bash
+mkdir -p docs/plans/done
+git mv docs/plans/2026-03-01-packages-molecule-fix-design.md docs/plans/done/
+git mv docs/plans/2026-03-01-packages-molecule-fix.md docs/plans/done/
+git commit -m "docs(plans): move packages molecule fix docs to done/
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push
+```
+
+---
+
+## Done
+
+Branch merged, PR closed, worktree deleted. All 3 CI environments verify real package installation.

--- a/docs/plans/2026-03-01-ssh-keys-molecule-fix-design.md
+++ b/docs/plans/2026-03-01-ssh-keys-molecule-fix-design.md
@@ -1,0 +1,73 @@
+# ssh_keys Molecule Test Fix — Design
+
+**Date:** 2026-03-01
+**Author:** Claude Sonnet 4.6
+**Status:** Approved
+
+## Problem
+
+The `ssh_keys` role has molecule scenarios (docker + vagrant + default) that were
+written in commit `341d65a` but have never been triggered in GHA. The tests are
+untested — we need to verify them green in all 3 CI environments: Docker
+(Arch+Ubuntu), Vagrant Arch, and Vagrant Ubuntu.
+
+## Analysis
+
+### Identified issues (code review)
+
+1. **`default/molecule.yml` — typo in test_sequence**: `idempotency` (invalid) must be
+   `idempotence`. Molecule does not recognise the misspelled step name.
+
+2. **`vagrant/prepare.yml` — missing Arch pacman cache update**: The gpu_drivers and
+   package_manager vagrant prepare files both call `community.general.pacman:
+   update_cache: true` for Arch. The ssh_keys vagrant prepare skips this, which can
+   cause "too old" metadata errors on the arch-base Vagrant box.
+
+3. **Tests otherwise correct**: Cross-platform OS guards in docker/prepare.yml are
+   present; shared/converge.yml and shared/verify.yml have correct logic for
+   testuser key injection, absent_user cleanup, and file-permission assertions.
+
+### GHA test matrix
+
+| Environment | Workflow | Scenario |
+|-------------|----------|----------|
+| Docker (Arch+Ubuntu) | `_molecule.yml` | `docker` |
+| Vagrant Arch | `_molecule-vagrant.yml` | `vagrant --platform-name arch-vm` |
+| Vagrant Ubuntu | `_molecule-vagrant.yml` | `vagrant --platform-name ubuntu-base` |
+
+## Changes
+
+### 1. Fix `default/molecule.yml` typo
+
+```yaml
+# Before
+- idempotency
+# After
+- idempotence
+```
+
+### 2. Add Arch pacman cache update to `vagrant/prepare.yml`
+
+Add before the user-creation tasks, following the gpu_drivers pattern:
+
+```yaml
+- name: Update pacman package cache (Arch)
+  community.general.pacman:
+    update_cache: true
+  when: ansible_facts['os_family'] == 'Archlinux'
+```
+
+## Workflow
+
+1. Create git worktree → branch `fix/ssh-keys-molecule-tests`
+2. Apply 2 changes above
+3. Push → open PR → GHA runs all 3 environments automatically
+4. If all green → merge PR → delete worktree
+5. If failures → diagnose → fix → push until green
+
+## Success criteria
+
+- `test (ssh_keys) / ssh_keys (Arch+Ubuntu/systemd)` → success
+- `test-vagrant (ssh_keys, arch-vm) / ssh_keys — arch-vm` → success
+- `test-vagrant (ssh_keys, ubuntu-base) / ssh_keys — ubuntu-base` → success
+- PR merged, branch deleted, worktree removed


### PR DESCRIPTION
## Summary

- `verify.yml` loaded `defaults/main.yml` via `vars_files` (Ansible precedence 14), silently overriding molecule inventory `group_vars` (precedence 4)
- Result: `packages_verify_expected = []` → empty assertion loop → tests passed trivially without checking any package
- Fix: remove `vars_files`, add `| default([])` guards so molecule inventory variables are correctly used
- Also removed redundant `check_mode` idempotence tasks — molecule's built-in `idempotence` step already covers this

## Packages now verified

| Scenario | Arch | Ubuntu |
|----------|------|--------|
| docker | git curl htop tmux unzip rsync vim fzf ripgrep jq base-devel | git curl htop tmux unzip rsync vim fzf ripgrep jq build-essential |
| vagrant | git curl htop tmux unzip rsync vim fzf jq base-devel | git curl htop tmux unzip rsync vim fzf jq build-essential |

## Test plan
- [ ] `test / packages` (Docker — Arch + Ubuntu)
- [ ] `test-vagrant / packages / arch-vm`
- [ ] `test-vagrant / packages / ubuntu-base`

🤖 Generated with [Claude Code](https://claude.com/claude-code)