### PR TITLE
fix(user): fix molecule tests for Docker + Vagrant

### DIFF
--- a/ansible/roles/user/molecule/docker/prepare.yml
+++ b/ansible/roles/user/molecule/docker/prepare.yml
@@ -15,6 +15,11 @@
         cache_valid_time: 3600
       when: ansible_facts['os_family'] == 'Debian'
 
+    - name: Ensure video group exists (required by testuser_extra)
+      ansible.builtin.group:
+        name: video
+        state: present
+
     - name: Ensure logrotate is installed (for sudo logrotate test)
       ansible.builtin.package:
         name: logrotate

--- a/ansible/roles/user/molecule/vagrant/converge.yml
+++ b/ansible/roles/user/molecule/vagrant/converge.yml
@@ -1,0 +1,37 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+  gather_facts: true
+
+  vars:
+    # Override owner to a test user (don't modify real running user)
+    user_owner:
+      name: testuser_owner
+      shell: /bin/bash
+      groups:
+        - "{{ user_sudo_group }}"
+      password_hash: ""
+      update_password: on_create
+      umask: "027"
+      password_max_age: 365
+      password_min_age: 1
+      password_warn_age: 7
+    user_additional_users:
+      - name: testuser_extra
+        shell: /bin/bash
+        groups:
+          - video
+        sudo: false
+        password_hash: ""
+        update_password: on_create
+        umask: "077"
+    user_manage_password_aging: false  # chage/shadow interactions vary across VMs
+    user_manage_umask: true
+    user_verify_root_lock: false       # vagrant boxes don't lock root by default
+    user_sudo_logrotate_enabled: true
+    user_sudo_log_input: false
+    user_sudo_log_output: false
+
+  roles:
+    - role: user

--- a/ansible/roles/user/molecule/vagrant/molecule.yml
+++ b/ansible/roles/user/molecule/vagrant/molecule.yml
@@ -31,7 +31,7 @@ provisioner:
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
   playbooks:
     prepare: prepare.yml
-    converge: ../shared/converge.yml
+    converge: converge.yml
     verify: ../shared/verify.yml
 
 verifier:

--- a/ansible/roles/user/molecule/vagrant/prepare.yml
+++ b/ansible/roles/user/molecule/vagrant/prepare.yml
@@ -31,3 +31,18 @@
         name: logrotate
         state: present
       when: ansible_facts['os_family'] == 'Debian'
+
+    # The user role deploys /etc/sudoers.d/wheel which requires a password for
+    # %wheel group. On Arch, this file sorts AFTER the vagrant user's NOPASSWD
+    # rule (alphabetically w > v), causing subsequent become tasks to fail.
+    # This file (zz-* prefix sorts after wheel) preserves passwordless sudo
+    # for the vagrant user throughout converge.
+    - name: Preserve passwordless sudo for vagrant user (Arch CI workaround)
+      ansible.builtin.copy:
+        content: "vagrant ALL=(ALL) NOPASSWD: ALL\n"
+        dest: /etc/sudoers.d/zz-molecule-vagrant-nopasswd
+        owner: root
+        group: root
+        mode: "0440"
+        validate: "/usr/sbin/visudo -cf %s"
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/ansible/roles/user/molecule/vagrant/prepare.yml
+++ b/ansible/roles/user/molecule/vagrant/prepare.yml
@@ -4,14 +4,30 @@
   become: true
   gather_facts: true
   tasks:
-    - name: Ensure logrotate is installed (Arch)
-      ansible.builtin.package:
-        name: logrotate
-        state: present
+    - name: Update pacman package cache (Arch)
+      community.general.pacman:
+        update_cache: true
       when: ansible_facts['os_family'] == 'Archlinux'
 
     - name: Update apt cache (Ubuntu)
       ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 3600
+      when: ansible_facts['os_family'] == 'Debian'
+
+    - name: Ensure video group exists (required by testuser_extra)
+      ansible.builtin.group:
+        name: video
+        state: present
+
+    - name: Ensure logrotate is installed (Arch)
+      community.general.pacman:
+        name: logrotate
+        state: present
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    - name: Ensure logrotate is installed (Ubuntu)
+      ansible.builtin.apt:
+        name: logrotate
+        state: present
       when: ansible_facts['os_family'] == 'Debian'


### PR DESCRIPTION
## Summary

- Fix `docker/prepare.yml`: create `video` group before converge so `testuser_extra` can be added to it without failing
- Fix `vagrant/prepare.yml`: add `logrotate` install for Ubuntu, `video` group creation, `update_cache` for Arch before package install
- Add `vagrant/converge.yml`: vagrant-specific variable overrides (separate from shared Docker converge)
- Update `vagrant/molecule.yml`: point converge to local `converge.yml` instead of `../shared/converge.yml`

## Test plan

- [ ] Docker scenario: Arch-systemd passes all steps (syntax/create/prepare/converge/idempotence/verify/destroy)
- [ ] Docker scenario: Ubuntu-systemd passes all steps
- [ ] Vagrant scenario: arch-vm passes all steps
- [ ] Vagrant scenario: ubuntu-base passes all steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)