### PR TITLE
feat(packages): OS-specific package lists in molecule — full Arch + Ubuntu equivalents

### DIFF
--- a/ansible/roles/packages/molecule/docker/molecule.yml
+++ b/ansible/roles/packages/molecule/docker/molecule.yml
@@ -43,26 +43,53 @@ provisioner:
     defaults:
       callbacks_enabled: profile_tasks
   inventory:
-    group_vars:
-      all:
-        packages_base: [git, curl, htop, tmux, unzip, rsync]
-        packages_editors: [vim]
-        packages_docker: []
-        packages_xorg: []
-        packages_wm: []
-        packages_filemanager: []
-        packages_network: []
-        packages_media: []
-        packages_desktop: []
-        packages_graphics: []
-        packages_session: []
-        packages_terminal: []
-        packages_fonts: []
-        packages_theming: []
+    host_vars:
+      Archlinux-systemd:
+        # Full production package list (mirrors ansible/inventory/group_vars/all/packages.yml)
+        packages_base: [git, curl, htop, tmux, unzip, rsync, openssh, chezmoi, nftables, cronie, sqlite]
+        packages_editors: [vim, neovim]
+        packages_docker: [docker, docker-compose, python-requests]
+        packages_xorg: [xorg, xorg-apps, xorg-xinit, xorg-drivers]
+        packages_wm: [picom, dmenu, rofi, dunst, feh, flameshot, gsimplecal]
+        packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
+        packages_network: [networkmanager, network-manager-applet]
+        packages_media: [playerctl, pamixer, brightnessctl]
+        packages_desktop: [xdg-utils, xdg-user-dirs, xss-lock, maim, imagemagick, lxappearance, arandr]
+        packages_graphics: [mesa]
+        packages_session: [lightdm]
+        packages_terminal: [alacritty, starship]
+        packages_fonts:
+          - ttf-jetbrains-mono-nerd
+          - ttf-firacode-nerd
+          - ttf-hack-nerd
+          - ttf-iosevka-nerd
+          - ttf-nerd-fonts-symbols
+          - ttf-font-awesome
+          - noto-fonts
+          - terminus-font
+        packages_theming: [papirus-icon-theme]
         packages_search: [fzf, ripgrep]
-        packages_viewers: [jq]
+        packages_viewers: [bat, jq]
         packages_distro:
-          Archlinux: [base-devel]
+          Archlinux: [base-devel, pacman-contrib, perl]
+
+      Ubuntu-systemd:
+        # Ubuntu-compatible equivalents (different names where needed, Arch-only packages excluded)
+        packages_base: [git, curl, htop, tmux, unzip, rsync, openssh-client, openssh-server, nftables, cron, sqlite3]
+        packages_editors: [vim, neovim]
+        packages_docker: [docker.io, python3-requests]
+        packages_xorg: [xorg, xinit]
+        packages_wm: [picom, suckless-tools, rofi, dunst, feh, flameshot]
+        packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
+        packages_network: [network-manager, network-manager-gnome]
+        packages_media: [playerctl, brightnessctl]
+        packages_desktop: [xdg-utils, xdg-user-dirs, xss-lock, imagemagick, lxappearance, arandr]
+        packages_session: [lightdm]
+        packages_fonts: [fonts-font-awesome, fonts-noto, xfonts-terminus]
+        packages_theming: [papirus-icon-theme]
+        packages_search: [fzf, ripgrep]
+        packages_viewers: [bat, jq]
+        packages_distro:
           Debian: [build-essential]
   playbooks:
     prepare: prepare.yml

--- a/ansible/roles/packages/molecule/docker/molecule.yml
+++ b/ansible/roles/packages/molecule/docker/molecule.yml
@@ -49,7 +49,7 @@ provisioner:
         packages_base: [git, curl, htop, tmux, unzip, rsync, openssh, chezmoi, nftables, cronie, sqlite]
         packages_editors: [vim, neovim]
         packages_docker: [docker, docker-compose, python-requests]
-        packages_xorg: [xorg-server, xrandr, xorg-xinit, xf86-input-libinput]
+        packages_xorg: [xorg-server, xorg-xrandr, xorg-xinit, xf86-input-libinput]
         packages_wm: [picom, dmenu, rofi, dunst, feh, flameshot, gsimplecal]
         packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
         packages_network: [networkmanager, network-manager-applet]

--- a/ansible/roles/packages/molecule/docker/molecule.yml
+++ b/ansible/roles/packages/molecule/docker/molecule.yml
@@ -49,7 +49,7 @@ provisioner:
         packages_base: [git, curl, htop, tmux, unzip, rsync, openssh, chezmoi, nftables, cronie, sqlite]
         packages_editors: [vim, neovim]
         packages_docker: [docker, docker-compose, python-requests]
-        packages_xorg: [xorg, xorg-apps, xorg-xinit, xorg-drivers]
+        packages_xorg: [xorg-server, xrandr, xorg-xinit, xf86-input-libinput]
         packages_wm: [picom, dmenu, rofi, dunst, feh, flameshot, gsimplecal]
         packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
         packages_network: [networkmanager, network-manager-applet]
@@ -64,7 +64,7 @@ provisioner:
           - ttf-hack-nerd
           - ttf-iosevka-nerd
           - ttf-nerd-fonts-symbols
-          - ttf-font-awesome
+          - otf-font-awesome
           - noto-fonts
           - terminus-font
         packages_theming: [papirus-icon-theme]

--- a/ansible/roles/packages/molecule/vagrant/molecule.yml
+++ b/ansible/roles/packages/molecule/vagrant/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
         packages_base: [git, curl, htop, tmux, unzip, rsync, openssh, chezmoi, nftables, cronie, sqlite]
         packages_editors: [vim, neovim]
         packages_docker: [docker, docker-compose, python-requests]
-        packages_xorg: [xorg-server, xrandr, xorg-xinit, xf86-input-libinput]
+        packages_xorg: [xorg-server, xorg-xrandr, xorg-xinit, xf86-input-libinput]
         packages_wm: [picom, dmenu, rofi, dunst, feh, flameshot, gsimplecal]
         packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
         packages_network: [networkmanager, network-manager-applet]

--- a/ansible/roles/packages/molecule/vagrant/molecule.yml
+++ b/ansible/roles/packages/molecule/vagrant/molecule.yml
@@ -32,7 +32,7 @@ provisioner:
         packages_base: [git, curl, htop, tmux, unzip, rsync, openssh, chezmoi, nftables, cronie, sqlite]
         packages_editors: [vim, neovim]
         packages_docker: [docker, docker-compose, python-requests]
-        packages_xorg: [xorg, xorg-apps, xorg-xinit, xorg-drivers]
+        packages_xorg: [xorg-server, xrandr, xorg-xinit, xf86-input-libinput]
         packages_wm: [picom, dmenu, rofi, dunst, feh, flameshot, gsimplecal]
         packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
         packages_network: [networkmanager, network-manager-applet]
@@ -47,7 +47,7 @@ provisioner:
           - ttf-hack-nerd
           - ttf-iosevka-nerd
           - ttf-nerd-fonts-symbols
-          - ttf-font-awesome
+          - otf-font-awesome
           - noto-fonts
           - terminus-font
         packages_theming: [papirus-icon-theme]

--- a/ansible/roles/packages/molecule/vagrant/molecule.yml
+++ b/ansible/roles/packages/molecule/vagrant/molecule.yml
@@ -26,26 +26,53 @@ provisioner:
     defaults:
       callbacks_enabled: profile_tasks
   inventory:
-    group_vars:
-      all:
-        packages_base: [git, curl, htop, tmux, unzip, rsync]
-        packages_editors: [vim]
-        packages_docker: []
-        packages_xorg: []
-        packages_wm: []
-        packages_filemanager: []
-        packages_network: []
-        packages_media: []
-        packages_desktop: []
-        packages_graphics: []
-        packages_session: []
-        packages_terminal: []
-        packages_fonts: []
-        packages_theming: []
-        packages_search: [fzf]
-        packages_viewers: [jq]
+    host_vars:
+      arch-vm:
+        # Full production package list (mirrors ansible/inventory/group_vars/all/packages.yml)
+        packages_base: [git, curl, htop, tmux, unzip, rsync, openssh, chezmoi, nftables, cronie, sqlite]
+        packages_editors: [vim, neovim]
+        packages_docker: [docker, docker-compose, python-requests]
+        packages_xorg: [xorg, xorg-apps, xorg-xinit, xorg-drivers]
+        packages_wm: [picom, dmenu, rofi, dunst, feh, flameshot, gsimplecal]
+        packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
+        packages_network: [networkmanager, network-manager-applet]
+        packages_media: [playerctl, pamixer, brightnessctl]
+        packages_desktop: [xdg-utils, xdg-user-dirs, xss-lock, maim, imagemagick, lxappearance, arandr]
+        packages_graphics: [mesa]
+        packages_session: [lightdm]
+        packages_terminal: [alacritty, starship]
+        packages_fonts:
+          - ttf-jetbrains-mono-nerd
+          - ttf-firacode-nerd
+          - ttf-hack-nerd
+          - ttf-iosevka-nerd
+          - ttf-nerd-fonts-symbols
+          - ttf-font-awesome
+          - noto-fonts
+          - terminus-font
+        packages_theming: [papirus-icon-theme]
+        packages_search: [fzf, ripgrep]
+        packages_viewers: [bat, jq]
         packages_distro:
-          Archlinux: [base-devel]
+          Archlinux: [base-devel, pacman-contrib, perl]
+
+      ubuntu-base:
+        # Ubuntu-compatible equivalents (different names where needed, Arch-only packages excluded)
+        packages_base: [git, curl, htop, tmux, unzip, rsync, openssh-client, openssh-server, nftables, cron, sqlite3]
+        packages_editors: [vim, neovim]
+        packages_docker: [docker.io, python3-requests]
+        packages_xorg: [xorg, xinit]
+        packages_wm: [picom, suckless-tools, rofi, dunst, feh, flameshot]
+        packages_filemanager: [thunar, thunar-volman, tumbler, gvfs]
+        packages_network: [network-manager, network-manager-gnome]
+        packages_media: [playerctl, brightnessctl]
+        packages_desktop: [xdg-utils, xdg-user-dirs, xss-lock, imagemagick, lxappearance, arandr]
+        packages_session: [lightdm]
+        packages_fonts: [fonts-font-awesome, fonts-noto, xfonts-terminus]
+        packages_theming: [papirus-icon-theme]
+        packages_search: [fzf, ripgrep]
+        packages_viewers: [bat, jq]
+        packages_distro:
           Debian: [build-essential]
   playbooks:
     prepare: prepare.yml


### PR DESCRIPTION
## Summary

Replace shared `group_vars.all` with per-platform `host_vars` so each OS is tested with its real package list.

### Arch (`Archlinux-systemd` / `arch-vm`)
Full production list from `packages.yml` — all categories, all packages.

### Ubuntu (`Ubuntu-systemd` / `ubuntu-base`)
Compatible equivalents with corrected package names:

| Category | Difference |
|----------|-----------|
| base | `openssh` → `openssh-client` + `openssh-server`; `cronie` → `cron`; `sqlite` → `sqlite3`; `chezmoi` excluded (not in apt) |
| docker | `docker` → `docker.io`; `python-requests` → `python3-requests`; docker-compose excluded |
| xorg | `xorg-apps`/`xorg-drivers`/`xorg-xinit` → `xinit` (Ubuntu packages differ) |
| wm | `dmenu` → `suckless-tools`; `gsimplecal` excluded |
| network | `networkmanager` → `network-manager`; `network-manager-applet` → `network-manager-gnome` |
| media | `pamixer` excluded (not in Ubuntu repos) |
| desktop | `maim` excluded (not in Ubuntu repos) |
| graphics | `mesa` excluded (no Ubuntu meta-package) |
| terminal | `alacritty`, `starship` excluded (not in apt) |
| fonts | Nerd Font packages excluded; `fonts-font-awesome`, `fonts-noto`, `xfonts-terminus` instead |

## Test plan
- [ ] `test / packages` (Docker — Arch + Ubuntu)
- [ ] `test-vagrant / packages / arch-vm`
- [ ] `test-vagrant / packages / ubuntu-base`

🤖 Generated with [Claude Code](https://claude.com/claude-code)