### PR TITLE
test(ssh): fill molecule coverage gaps — access control, Teleport, SFTP chroot, moduli

### DIFF
--- a/ansible/roles/ssh/molecule/default/molecule.yml
+++ b/ansible/roles/ssh/molecule/default/molecule.yml
@@ -18,11 +18,15 @@ provisioner:
     host_vars:
       localhost:
         ansible_connection: local
+        ssh_user: "{{ ansible_user_id }}"
+        ssh_banner_enabled: true
+        ssh_moduli_cleanup: false
+        ssh_allow_groups: []
   playbooks:
     converge: ../shared/converge.yml
     verify: ../shared/verify.yml
   env:
-    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/roles"
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
 
 verifier:
   name: ansible

--- a/ansible/roles/ssh/molecule/docker/molecule.yml
+++ b/ansible/roles/ssh/molecule/docker/molecule.yml
@@ -48,13 +48,13 @@ provisioner:
         ansible_user: root
         ssh_user: root
         ssh_banner_enabled: true
-        ssh_moduli_cleanup: true
+        ssh_moduli_cleanup: true  # override default (false); verifies moduli pruning path
         ssh_allow_groups: []
       Ubuntu-systemd:
         ansible_user: root
         ssh_user: root
         ssh_banner_enabled: true
-        ssh_moduli_cleanup: true
+        ssh_moduli_cleanup: true  # override default (false); verifies moduli pruning path
         ssh_allow_groups: []
   playbooks:
     prepare: prepare.yml

--- a/ansible/roles/ssh/molecule/docker/molecule.yml
+++ b/ansible/roles/ssh/molecule/docker/molecule.yml
@@ -46,8 +46,16 @@ provisioner:
     host_vars:
       Archlinux-systemd:
         ansible_user: root
+        ssh_user: root
+        ssh_banner_enabled: true
+        ssh_moduli_cleanup: true
+        ssh_allow_groups: []
       Ubuntu-systemd:
         ansible_user: root
+        ssh_user: root
+        ssh_banner_enabled: true
+        ssh_moduli_cleanup: true
+        ssh_allow_groups: []
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml

--- a/ansible/roles/ssh/molecule/docker/molecule.yml
+++ b/ansible/roles/ssh/molecule/docker/molecule.yml
@@ -63,6 +63,36 @@ platforms:
       - 8.8.8.8
       - 8.8.4.4
 
+  - name: Archlinux-features
+    image: "${MOLECULE_ARCH_IMAGE:-ghcr.io/textyre/arch-base:latest}"
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
+  - name: Ubuntu-features
+    image: "${MOLECULE_UBUNTU_IMAGE:-ghcr.io/textyre/ubuntu-base:latest}"
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
 provisioner:
   name: ansible
   options:
@@ -108,6 +138,22 @@ provisioner:
           - badgroup
         ssh_deny_users:
           - baduser
+      Archlinux-features:
+        ansible_user: root
+        ssh_user: root
+        ssh_allow_groups: []
+        ssh_teleport_integration: true
+        ssh_sftp_chroot_enabled: true
+        ssh_listen_addresses:
+          - "127.0.0.1"
+      Ubuntu-features:
+        ansible_user: root
+        ssh_user: root
+        ssh_allow_groups: []
+        ssh_teleport_integration: true
+        ssh_sftp_chroot_enabled: true
+        ssh_listen_addresses:
+          - "127.0.0.1"
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml

--- a/ansible/roles/ssh/molecule/docker/molecule.yml
+++ b/ansible/roles/ssh/molecule/docker/molecule.yml
@@ -33,6 +33,36 @@ platforms:
       - 8.8.8.8
       - 8.8.4.4
 
+  - name: Archlinux-access-control
+    image: "${MOLECULE_ARCH_IMAGE:-ghcr.io/textyre/arch-base:latest}"
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
+  - name: Ubuntu-access-control
+    image: "${MOLECULE_UBUNTU_IMAGE:-ghcr.io/textyre/ubuntu-base:latest}"
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
 provisioner:
   name: ansible
   options:
@@ -56,6 +86,28 @@ provisioner:
         ssh_banner_enabled: true
         ssh_moduli_cleanup: true  # override default (false); verifies moduli pruning path
         ssh_allow_groups: []
+      Archlinux-access-control:
+        ansible_user: root
+        ssh_user: root
+        ssh_allow_groups:
+          - sshusers
+        ssh_allow_users:
+          - root
+        ssh_deny_groups:
+          - badgroup
+        ssh_deny_users:
+          - baduser
+      Ubuntu-access-control:
+        ansible_user: root
+        ssh_user: root
+        ssh_allow_groups:
+          - sshusers
+        ssh_allow_users:
+          - root
+        ssh_deny_groups:
+          - badgroup
+        ssh_deny_users:
+          - baduser
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml

--- a/ansible/roles/ssh/molecule/docker/prepare.yml
+++ b/ansible/roles/ssh/molecule/docker/prepare.yml
@@ -33,3 +33,16 @@
         groups: sshusers
         append: true
       when: inventory_hostname is search('access-control')
+
+    - name: Create fake Teleport user CA key file (features platforms)
+      ansible.builtin.copy:
+        content: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForMoleculeTesting fake-teleport-ca\n"
+        dest: /etc/ssh/teleport_user_ca.pub
+        mode: "0644"
+      when: inventory_hostname is search('features')
+
+    - name: Create sftponly group (features platforms)
+      ansible.builtin.group:
+        name: sftponly
+        state: present
+      when: inventory_hostname is search('features')

--- a/ansible/roles/ssh/molecule/docker/prepare.yml
+++ b/ansible/roles/ssh/molecule/docker/prepare.yml
@@ -36,7 +36,7 @@
 
     - name: Create fake Teleport user CA key file (features platforms)
       ansible.builtin.copy:
-        content: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKeyForMoleculeTesting fake-teleport-ca\n"
+        content: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA fake-teleport-ca\n"
         dest: /etc/ssh/teleport_user_ca.pub
         mode: "0644"
       when: inventory_hostname is search('features')

--- a/ansible/roles/ssh/molecule/docker/prepare.yml
+++ b/ansible/roles/ssh/molecule/docker/prepare.yml
@@ -20,3 +20,16 @@
         path: /run/sshd
         state: directory
         mode: "0755"
+
+    - name: Create sshusers group (access-control platforms)
+      ansible.builtin.group:
+        name: sshusers
+        state: present
+      when: inventory_hostname is search('access-control')
+
+    - name: Add root to sshusers group (access-control platforms)
+      ansible.builtin.user:
+        name: root
+        groups: sshusers
+        append: true
+      when: inventory_hostname is search('access-control')

--- a/ansible/roles/ssh/molecule/docker/prepare.yml
+++ b/ansible/roles/ssh/molecule/docker/prepare.yml
@@ -34,6 +34,13 @@
         append: true
       when: inventory_hostname is search('access-control')
 
+    - name: Ensure /etc/ssh exists (features platforms — Ubuntu container lacks it pre-install)
+      ansible.builtin.file:
+        path: /etc/ssh
+        state: directory
+        mode: "0755"
+      when: inventory_hostname is search('features')
+
     - name: Create fake Teleport user CA key file (features platforms)
       ansible.builtin.copy:
         content: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA fake-teleport-ca\n"

--- a/ansible/roles/ssh/molecule/shared/converge.yml
+++ b/ansible/roles/ssh/molecule/shared/converge.yml
@@ -3,10 +3,6 @@
   hosts: all
   become: true
   gather_facts: true
+
   roles:
     - role: ssh
-      vars:
-        ssh_user: root
-        ssh_banner_enabled: true
-        ssh_moduli_cleanup: true
-        ssh_allow_groups: []

--- a/ansible/roles/ssh/molecule/shared/verify.yml
+++ b/ansible/roles/ssh/molecule/shared/verify.yml
@@ -581,6 +581,34 @@
       when: inventory_hostname is search('access-control')
 
     # ================================================================
+    #  Features directives (features platforms)
+    # ================================================================
+
+    - name: Assert ListenAddress 127.0.0.1 in config (features)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('ListenAddress\s+127\.0\.0\.1\b')
+        fail_msg: "ListenAddress 127.0.0.1 not found in sshd_config"
+      when: inventory_hostname is search('features')
+
+    - name: Assert TrustedUserCAKeys directive in config (features)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('TrustedUserCAKeys\s+/etc/ssh/teleport_user_ca\.pub')
+        fail_msg: "TrustedUserCAKeys /etc/ssh/teleport_user_ca.pub not found in sshd_config"
+      when: inventory_hostname is search('features')
+
+    - name: Assert SFTP chroot Match Group block in config (features)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('Match\s+Group\s+sftponly')
+        fail_msg: "Match Group sftponly block not found in sshd_config"
+      when: inventory_hostname is search('features')
+
+    - name: Assert ChrootDirectory in config (features)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('ChrootDirectory\s+/home/%u')
+        fail_msg: "ChrootDirectory /home/%u not found in sshd_config"
+      when: inventory_hostname is search('features')
+
+    # ================================================================
     #  Diagnostic
     # ================================================================
 

--- a/ansible/roles/ssh/molecule/shared/verify.yml
+++ b/ansible/roles/ssh/molecule/shared/verify.yml
@@ -134,12 +134,12 @@
 
     - name: Assert Port 22
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('Port\s+22\b')
+        that: _ssh_verify_sshd_content is regex('Port\s+22\\b')
         fail_msg: "Port is not set to 22"
 
     - name: Assert AddressFamily inet
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('AddressFamily\s+inet\b')
+        that: _ssh_verify_sshd_content is regex('AddressFamily\s+inet\\b')
         fail_msg: "AddressFamily is not set to 'inet'"
 
     - name: Assert PasswordAuthentication no
@@ -558,25 +558,25 @@
 
     - name: Assert AllowGroups sshusers in config (access-control)
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('AllowGroups\s+sshusers\b')
+        that: _ssh_verify_sshd_content is regex('AllowGroups\s+sshusers\\b')
         fail_msg: "AllowGroups sshusers not found in sshd_config"
       when: inventory_hostname is search('access-control')
 
     - name: Assert AllowUsers root in config (access-control)
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('AllowUsers\s+root\b')
+        that: _ssh_verify_sshd_content is regex('AllowUsers\s+root\\b')
         fail_msg: "AllowUsers root not found in sshd_config"
       when: inventory_hostname is search('access-control')
 
     - name: Assert DenyGroups badgroup in config (access-control)
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('DenyGroups\s+badgroup\b')
+        that: _ssh_verify_sshd_content is regex('DenyGroups\s+badgroup\\b')
         fail_msg: "DenyGroups badgroup not found in sshd_config"
       when: inventory_hostname is search('access-control')
 
     - name: Assert DenyUsers baduser in config (access-control)
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('DenyUsers\s+baduser\b')
+        that: _ssh_verify_sshd_content is regex('DenyUsers\s+baduser\\b')
         fail_msg: "DenyUsers baduser not found in sshd_config"
       when: inventory_hostname is search('access-control')
 
@@ -586,7 +586,7 @@
 
     - name: Assert ListenAddress 127.0.0.1 in config (features)
       ansible.builtin.assert:
-        that: _ssh_verify_sshd_content is regex('ListenAddress\s+127\.0\.0\.1\b')
+        that: _ssh_verify_sshd_content is regex('ListenAddress\s+127\.0\.0\.1\\b')
         fail_msg: "ListenAddress 127.0.0.1 not found in sshd_config"
       when: inventory_hostname is search('features')
 

--- a/ansible/roles/ssh/molecule/shared/verify.yml
+++ b/ansible/roles/ssh/molecule/shared/verify.yml
@@ -553,6 +553,34 @@
       when: not (inventory_hostname is search('access-control'))
 
     # ================================================================
+    #  Access control directives (access-control platforms)
+    # ================================================================
+
+    - name: Assert AllowGroups sshusers in config (access-control)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('AllowGroups\s+sshusers\b')
+        fail_msg: "AllowGroups sshusers not found in sshd_config"
+      when: inventory_hostname is search('access-control')
+
+    - name: Assert AllowUsers root in config (access-control)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('AllowUsers\s+root\b')
+        fail_msg: "AllowUsers root not found in sshd_config"
+      when: inventory_hostname is search('access-control')
+
+    - name: Assert DenyGroups badgroup in config (access-control)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('DenyGroups\s+badgroup\b')
+        fail_msg: "DenyGroups badgroup not found in sshd_config"
+      when: inventory_hostname is search('access-control')
+
+    - name: Assert DenyUsers baduser in config (access-control)
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('DenyUsers\s+baduser\b')
+        fail_msg: "DenyUsers baduser not found in sshd_config"
+      when: inventory_hostname is search('access-control')
+
+    # ================================================================
     #  Diagnostic
     # ================================================================
 

--- a/ansible/roles/ssh/molecule/shared/verify.yml
+++ b/ansible/roles/ssh/molecule/shared/verify.yml
@@ -458,26 +458,31 @@
       ansible.builtin.stat:
         path: /etc/issue.net
       register: _ssh_verify_banner
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
 
     - name: Assert banner file exists
       ansible.builtin.assert:
         that: _ssh_verify_banner.stat.exists
         fail_msg: "/etc/issue.net not found (ssh_banner_enabled was true in converge)"
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
 
     - name: Assert Banner directive in sshd_config
       ansible.builtin.assert:
         that: _ssh_verify_sshd_content is regex('Banner\s+/etc/issue.net')
         fail_msg: "Banner directive not found in sshd_config"
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
 
     - name: Read banner file content
       ansible.builtin.slurp:
         src: /etc/issue.net
       register: _ssh_verify_banner_content
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
 
     - name: Assert banner file contains warning content
       ansible.builtin.assert:
         that: "'====' in (_ssh_verify_banner_content.content | b64decode)"
         fail_msg: "Banner /etc/issue.net does not contain expected warning content (missing '====')"
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
 
     # ================================================================
     #  SFTP subsystem
@@ -518,6 +523,7 @@
         fail_msg: >-
           AllowGroups directive is present in sshd_config but ssh_allow_groups
           was set to [] in converge — template is not respecting empty list
+      when: not (inventory_hostname is search('access-control'))
 
     # ================================================================
     #  Diagnostic

--- a/ansible/roles/ssh/molecule/shared/verify.yml
+++ b/ansible/roles/ssh/molecule/shared/verify.yml
@@ -132,6 +132,16 @@
         that: _ssh_verify_sshd_content is regex('PermitRootLogin\s+no')
         fail_msg: "PermitRootLogin is not set to 'no'"
 
+    - name: Assert Port 22
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('Port\s+22\b')
+        fail_msg: "Port is not set to 22"
+
+    - name: Assert AddressFamily inet
+      ansible.builtin.assert:
+        that: _ssh_verify_sshd_content is regex('AddressFamily\s+inet\b')
+        fail_msg: "AddressFamily is not set to 'inet'"
+
     - name: Assert PasswordAuthentication no
       ansible.builtin.assert:
         that: _ssh_verify_sshd_content is regex('PasswordAuthentication\s+no')
@@ -494,6 +504,23 @@
         fail_msg: "SFTP subsystem not configured (expected 'Subsystem sftp internal-sftp')"
 
     # ================================================================
+    #  DH moduli cleanup verification (systemd + vagrant platforms)
+    # ================================================================
+
+    - name: Check for weak DH moduli after cleanup
+      ansible.builtin.command:
+        cmd: awk '$5 < 3072 { print }' /etc/ssh/moduli
+      register: _ssh_verify_weak_moduli
+      changed_when: false
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
+
+    - name: Assert no weak DH moduli remain
+      ansible.builtin.assert:
+        that: _ssh_verify_weak_moduli.stdout == ''
+        fail_msg: "Weak DH moduli still present (< 3072 bits):\n{{ _ssh_verify_weak_moduli.stdout | truncate(500) }}"
+      when: inventory_hostname is search('systemd') or inventory_hostname in ['arch-vm', 'ubuntu-base']
+
+    # ================================================================
     #  Config syntax validation
     # ================================================================
 
@@ -532,8 +559,10 @@
     - name: Show verify result
       ansible.builtin.debug:
         msg: >-
-          SSH verify passed: packages installed, service enabled,
-          sshd_config correct (0600 root, all security directives verified),
-          host keys correct (ed25519+RSA present with 0600, DSA/ECDSA absent),
+          SSH verify passed on {{ inventory_hostname }}: packages installed, service enabled+running,
+          sshd_config correct (0600 root, all security directives verified, Port+AddressFamily checked),
+          host keys correct (ed25519+RSA present with correct perms, DSA/ECDSA absent),
           cryptography validated (ciphers, MACs, KEX),
-          banner deployed, sshd -t passed.
+          AllowGroups absent (or platform-specific for access-control/features),
+          banner checked (systemd+vagrant platforms), moduli verified (systemd+vagrant platforms),
+          sshd -t passed.

--- a/ansible/roles/ssh/molecule/vagrant/molecule.yml
+++ b/ansible/roles/ssh/molecule/vagrant/molecule.yml
@@ -26,16 +26,17 @@ provisioner:
     defaults:
       callbacks_enabled: profile_tasks
   inventory:
+    # ansible_user is injected automatically by the Vagrant driver (defaults to 'vagrant')
     host_vars:
       arch-vm:
         ssh_user: vagrant
         ssh_banner_enabled: true
-        ssh_moduli_cleanup: true
+        ssh_moduli_cleanup: true  # override default (false); verifies moduli pruning path
         ssh_allow_groups: []
       ubuntu-base:
         ssh_user: vagrant
         ssh_banner_enabled: true
-        ssh_moduli_cleanup: true
+        ssh_moduli_cleanup: true  # override default (false); verifies moduli pruning path
         ssh_allow_groups: []
   playbooks:
     prepare: prepare.yml

--- a/ansible/roles/ssh/molecule/vagrant/molecule.yml
+++ b/ansible/roles/ssh/molecule/vagrant/molecule.yml
@@ -25,6 +25,18 @@ provisioner:
   config_options:
     defaults:
       callbacks_enabled: profile_tasks
+  inventory:
+    host_vars:
+      arch-vm:
+        ssh_user: vagrant
+        ssh_banner_enabled: true
+        ssh_moduli_cleanup: true
+        ssh_allow_groups: []
+      ubuntu-base:
+        ssh_user: vagrant
+        ssh_banner_enabled: true
+        ssh_moduli_cleanup: true
+        ssh_allow_groups: []
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml


### PR DESCRIPTION
## Summary

- **Add 4 new Docker platforms**: `*-access-control` (AllowGroups/AllowUsers/DenyGroups/DenyUsers) and `*-features` (Teleport CA + SFTP chroot + ListenAddress) — 6 platforms total
- **Refactor variable management**: Remove `vars:` block from `converge.yml`, move all per-platform role variables to per-scenario `inventory.host_vars` (enables true per-platform configuration)
- **70 assertions** (was 59): Added Port 22, AddressFamily inet, DH moduli cleanup verification, access-control directives (4 new), features directives (4 new), banner/AllowGroups guards
- **Fix default scenario**: Correct `ANSIBLE_ROLES_PATH`, add host_vars

## Test plan

- [ ] Docker CI: all 6 platforms pass (`syntax → create → prepare → converge → idempotence → verify → destroy`)
  - `Archlinux-systemd` / `Ubuntu-systemd`: banner, moduli, all existing assertions
  - `Archlinux-access-control` / `Ubuntu-access-control`: AllowGroups sshusers, AllowUsers root, DenyGroups badgroup, DenyUsers baduser
  - `Archlinux-features` / `Ubuntu-features`: TrustedUserCAKeys, Match Group sftponly, ChrootDirectory, ListenAddress 127.0.0.1
- [ ] Vagrant CI: `arch-vm` and `ubuntu-base` pass (existing assertions + moduli + banner)
- [ ] No regression on systemd platform assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)