### PR TITLE
fix(chezmoi): resolve 5 root causes of failing molecule tests

### DIFF
--- a/ansible/roles/chezmoi/molecule/docker/molecule.yml
+++ b/ansible/roles/chezmoi/molecule/docker/molecule.yml
@@ -54,7 +54,9 @@ provisioner:
         chezmoi_verify_fixture: true
         chezmoi_verify_full: false
       Ubuntu-systemd:
-        chezmoi_install_method: apt
+        # chezmoi is not in Debian/Ubuntu repos; install via official script.
+        # Binary lands at ~/.local/bin/chezmoi.
+        chezmoi_install_method: script
         chezmoi_user: testuser
         chezmoi_source_dir: /opt/dotfiles
         chezmoi_verify_has_dotfiles: true

--- a/ansible/roles/chezmoi/molecule/shared/verify.yml
+++ b/ansible/roles/chezmoi/molecule/shared/verify.yml
@@ -3,10 +3,19 @@
   hosts: all
   become: true
   gather_facts: true
-  vars_files:
-    - ../../defaults/main.yml
+
+  # NOTE: Do NOT use vars_files to load ../../defaults/main.yml here.
+  # vars_files (precedence 9) overrides inventory host_vars (precedence 4),
+  # which breaks chezmoi_user set by molecule scenarios.
 
   tasks:
+
+    # ---- Resolve user (fallback when inventory doesn't set chezmoi_user) ----
+
+    - name: Set chezmoi_user default if not provided by inventory
+      ansible.builtin.set_fact:
+        chezmoi_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['user_id']) }}"
+      when: chezmoi_user is not defined
 
     # ---- Resolve user home (needed for all checks) ----
 
@@ -59,10 +68,20 @@
           Got: {{ _chezmoi_verify_version.stdout }}
 
     # ---- Tier 1: chezmoi source directory initialized ----
+    # When chezmoi_source_dir is set (fixture scenarios), check that path.
+    # Otherwise check the default ~/.local/share/chezmoi.
+
+    - name: Set expected source directory path
+      ansible.builtin.set_fact:
+        _chezmoi_verify_expected_source: >-
+          {{ chezmoi_source_dir
+             if chezmoi_source_dir is defined
+             else _chezmoi_verify_home ~ '/.local/share/chezmoi' }}
+      when: chezmoi_verify_has_dotfiles | default(false)
 
     - name: Check chezmoi source directory exists
       ansible.builtin.stat:
-        path: "{{ _chezmoi_verify_home }}/.local/share/chezmoi"
+        path: "{{ _chezmoi_verify_expected_source }}"
       register: _chezmoi_verify_source_dir
       when: chezmoi_verify_has_dotfiles | default(false)
 
@@ -71,7 +90,7 @@
         that:
           - _chezmoi_verify_source_dir.stat.exists
           - _chezmoi_verify_source_dir.stat.isdir
-        fail_msg: "chezmoi source directory not found at ~/.local/share/chezmoi"
+        fail_msg: "chezmoi source directory not found at {{ _chezmoi_verify_expected_source }}"
       when: chezmoi_verify_has_dotfiles | default(false)
 
     # ---- Tier 1: chezmoi config file deployed ----

--- a/ansible/roles/chezmoi/molecule/vagrant/molecule.yml
+++ b/ansible/roles/chezmoi/molecule/vagrant/molecule.yml
@@ -28,11 +28,13 @@ provisioner:
   inventory:
     host_vars:
       arch-vm:
+        chezmoi_user: vagrant
         chezmoi_install_method: pacman
         chezmoi_source_dir: /opt/dotfiles
         chezmoi_verify_has_dotfiles: true
         chezmoi_verify_fixture: true
       ubuntu-base:
+        chezmoi_user: vagrant
         chezmoi_install_method: script
         chezmoi_source_dir: /opt/dotfiles
         chezmoi_verify_has_dotfiles: true

--- a/ansible/roles/chezmoi/molecule/vagrant/prepare.yml
+++ b/ansible/roles/chezmoi/molecule/vagrant/prepare.yml
@@ -11,18 +11,24 @@
         cache_valid_time: 3600
       when: ansible_facts['os_family'] == 'Debian'
 
-    - name: Ensure curl is installed (Ubuntu -- needed for get.chezmoi.io)
+    - name: Install curl and git (Ubuntu)
       ansible.builtin.apt:
-        name: curl
+        name:
+          - curl
+          - git
         state: present
       when: ansible_facts['os_family'] == 'Debian'
 
-    # Fixture dotfiles -- minimal source so chezmoi init --source /opt/dotfiles succeeds
+    # Fixture dotfiles -- minimal source so chezmoi init --source /opt/dotfiles succeeds.
+    # Owner must be vagrant (the chezmoi_user in this scenario) because
+    # chezmoi init creates .git inside the source directory.
     - name: Create dotfiles fixture directory
       ansible.builtin.file:
         path: /opt/dotfiles
         state: directory
         mode: '0755'
+        owner: vagrant
+        group: vagrant
 
     - name: Deploy minimal .chezmoi.toml.tmpl fixture
       ansible.builtin.copy:
@@ -31,9 +37,13 @@
           [data]
             theme_name = "dracula"
         mode: '0644'
+        owner: vagrant
+        group: vagrant
 
     - name: Deploy minimal test marker dotfile
       ansible.builtin.copy:
         dest: /opt/dotfiles/dot_chezmoi_test_marker
         content: "chezmoi-molecule-test\n"
         mode: '0644'
+        owner: vagrant
+        group: vagrant

--- a/ansible/roles/chezmoi/tasks/main.yml
+++ b/ansible/roles/chezmoi/tasks/main.yml
@@ -104,7 +104,7 @@
   become: true
   become_user: "{{ chezmoi_user }}"
   ansible.builtin.command:
-    cmd: find {{ chezmoi_user_home }}/.local/share/chezmoi -mindepth 2 -name '.chezmoidata' -type d
+    cmd: find {{ chezmoi_source_dir }} -mindepth 2 -name '.chezmoidata' -type d
   register: chezmoi_nested_check
   changed_when: false
   failed_when: chezmoi_nested_check.stdout | length > 0


### PR DESCRIPTION
## Summary

Fixes all 5 root causes that caused chezmoi molecule tests to fail across Docker and Vagrant scenarios.

### Root causes fixed

- **ROOT-1**: `vars_files` in verify.yml (Ansible precedence 9) overrode molecule inventory `host_vars` (precedence 4), causing `chezmoi_user` to resolve to `root` instead of `testuser` in Docker containers
- **ROOT-2**: verify.yml hardcoded source dir check at `~/.local/share/chezmoi`, but fixture scenarios use `--source /opt/dotfiles` — chezmoi doesn't create the default dir when custom source is specified
- **ROOT-3**: Vagrant prepare.yml created `/opt/dotfiles` owned by root — chezmoi init as vagrant user failed with `mkdir .git: permission denied`
- **ROOT-4**: Vagrant molecule.yml lacked `chezmoi_user` in host_vars + missing `git` package in Ubuntu prepare
- **ROOT-5**: Docker molecule.yml used `chezmoi_install_method: apt` which is not a valid method (role supports `pacman`/`script` only)

### Files changed

| File | Change |
|------|--------|
| `molecule/shared/verify.yml` | Remove `vars_files`, add `set_fact` fallback + dynamic source dir path |
| `molecule/docker/molecule.yml` | `apt` → `script` for Ubuntu |
| `molecule/vagrant/molecule.yml` | Add `chezmoi_user: vagrant` to both platforms |
| `molecule/vagrant/prepare.yml` | Add `owner: vagrant` + `git` install for Ubuntu |
| `tasks/main.yml` | Fix nested chezmoidata guard to use `chezmoi_source_dir` |

## Test plan

- [x] CI: YAML Lint & Syntax — PASS
- [x] CI: Ansible Lint — PASS
- [x] CI: chezmoi Docker (Arch+Ubuntu/systemd) — PASS
- [x] CI: chezmoi Vagrant arch-vm — PASS
- [x] CI: chezmoi Vagrant ubuntu-base — PASS

Closes #28

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>