### PR TITLE
fix(timezone): full role review — bugs, standards, test coverage

### DIFF
--- a/ansible/molecule/shared/prepare-docker.yml
+++ b/ansible/molecule/shared/prepare-docker.yml
@@ -1,0 +1,34 @@
+---
+# Shared Docker prepare — import at the TOP of every role's
+# molecule/docker/prepare.yml to ensure package databases are fresh.
+#
+# Usage in role prepare.yml:
+#
+#   - name: Bootstrap Docker container
+#     ansible.builtin.import_playbook: ../../../../molecule/shared/prepare-docker.yml
+#
+#   - name: Prepare (role-specific)
+#     hosts: all
+#     become: true
+#     gather_facts: true
+#     tasks:
+#       - name: Install role-specific deps
+#         ...
+
+- name: Bootstrap Docker container
+  hosts: all
+  become: true
+  gather_facts: true
+  tasks:
+    # ---- Arch Linux ----
+    - name: Update pacman package cache (Arch)
+      community.general.pacman:
+        update_cache: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
+    # ---- Ubuntu/Debian ----
+    - name: Update apt cache (Ubuntu)
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_facts['os_family'] == 'Debian'

--- a/ansible/roles/timezone/README.md
+++ b/ansible/roles/timezone/README.md
@@ -4,25 +4,28 @@ Sets the system timezone and ensures the `tzdata` database package is installed.
 
 ## What this role does
 
-- [x] Installs `tzdata` package (name resolved from `timezone_packages_tzdata` dict, keyed by `os_family`)
+- [x] Asserts OS family is supported (ROLE-003 preflight)
+- [x] Validates `timezone_name` is defined and non-empty
+- [x] Installs `tzdata` package (name resolved from `timezone_packages_tzdata` dict, keyed by `os_family`; skipped when undefined)
 - [x] Sets system timezone via `community.general.timezone` (`/etc/localtime` symlink on all platforms; `/etc/timezone` only on non-systemd Debian/Ubuntu)
-- [x] Verifies the applied timezone via `readlink -f /etc/localtime`
+- [x] Verifies the applied timezone via `readlink -f /etc/localtime` and `timedatectl` on systemd (ROLE-005, `tasks/verify.yml`)
 - [x] Restarts cron after a timezone change (skipped when cron is not installed)
+- [x] Reports execution phases via `common/report_phase.yml` (ROLE-008)
 
 ## Variables
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `timezone_name` | `"UTC"` | Timezone name in tz database format (`timedatectl list-timezones`) |
+| `timezone_name` | `"UTC"` | Timezone name in tz database format (`ls /usr/share/zoneinfo/`) |
 | `timezone_packages_tzdata` | _(undefined)_ | Package name dict keyed by `os_family` with `default` fallback. Task is skipped when undefined. |
 
-Production values are set in `group_vars/all/system.yml`:
+Production values are set in `inventory/group_vars/all/system.yml`:
 
 ```yaml
 timezone_name: "Asia/Almaty"
 ```
 
-`timezone_packages_tzdata` comes from `group_vars/all/packages.yml`:
+`timezone_packages_tzdata` comes from `inventory/group_vars/all/packages.yml`:
 
 ```yaml
 timezone_packages_tzdata:
@@ -64,8 +67,23 @@ molecule test -s docker
 molecule test -s vagrant
 ```
 
-Vagrant requires `libvirt` provider. All three scenarios share `molecule/shared/converge.yml` and `molecule/shared/verify.yml`.
-Scenario test vars are defined in each `molecule.yml` under `provisioner.inventory.group_vars.all`.
+All three scenarios share `molecule/shared/converge.yml` and `molecule/shared/verify.yml`.
+Vagrant requires `libvirt` provider.
+
+Docker prepare imports shared `molecule/shared/prepare-docker.yml` for cache updates,
+then adds role-specific cron installation for Archlinux only.
+
+### Docker scenario — platform-differentiated testing
+
+| Platform | Cron? | `timezone_packages_tzdata`? | Tests |
+|----------|-------|----------------------------|-------|
+| Archlinux-systemd | installed | defined (host_vars) | handler fires, tzdata installed |
+| Ubuntu-systemd | absent | undefined | handler skips, tzdata install skipped |
+
+### Negative tests
+
+- Invalid timezone name (`Invalid/NotATimezone`) is rejected by `community.general.timezone`
+- Timezone zone file validated against `/usr/share/zoneinfo/`
 
 ## Supported platforms
 

--- a/ansible/roles/timezone/defaults/main.yml
+++ b/ansible/roles/timezone/defaults/main.yml
@@ -1,5 +1,13 @@
 ---
 # === Таймзона ===
-# Имя таймзоны в формате tz database (timedatectl list-timezones)
+# Имя таймзоны в формате tz database (ls /usr/share/zoneinfo/)
 # Реальное значение задаётся в group_vars/all/system.yml
 timezone_name: "UTC"
+
+# Поддерживаемые дистрибутивы (ROLE-003)
+_timezone_supported_os:
+  - Archlinux
+  - Debian
+  - RedHat
+  - Void
+  - Gentoo

--- a/ansible/roles/timezone/meta/main.yml
+++ b/ansible/roles/timezone/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   author: textyre
   description: >-
     Set system timezone. Supports Arch Linux, Fedora, Ubuntu, Void Linux, Gentoo.
-    Installs tzdata via packages_tzdata when defined.
+    Installs tzdata via timezone_packages_tzdata when defined.
   license: MIT
   min_ansible_version: "2.15"
   platforms:

--- a/ansible/roles/timezone/molecule/default/molecule.yml
+++ b/ansible/roles/timezone/molecule/default/molecule.yml
@@ -22,7 +22,7 @@ provisioner:
       all:
         timezone_name: "Asia/Almaty"
         timezone_packages_tzdata:
-          Gentoo: "timezone-data"
+          Gentoo: "sys-libs/timezone-data"
           default: "tzdata"
   playbooks:
     converge: ../shared/converge.yml

--- a/ansible/roles/timezone/molecule/docker/molecule.yml
+++ b/ansible/roles/timezone/molecule/docker/molecule.yml
@@ -45,7 +45,7 @@ provisioner:
       all:
         timezone_name: "Asia/Almaty"
         timezone_packages_tzdata:
-          Gentoo: "timezone-data"
+          Gentoo: "sys-libs/timezone-data"
           default: "tzdata"
   playbooks:
     prepare: prepare.yml

--- a/ansible/roles/timezone/molecule/docker/molecule.yml
+++ b/ansible/roles/timezone/molecule/docker/molecule.yml
@@ -44,6 +44,8 @@ provisioner:
     group_vars:
       all:
         timezone_name: "Asia/Almaty"
+    host_vars:
+      Archlinux-systemd:
         timezone_packages_tzdata:
           Gentoo: "sys-libs/timezone-data"
           default: "tzdata"

--- a/ansible/roles/timezone/molecule/docker/prepare.yml
+++ b/ansible/roles/timezone/molecule/docker/prepare.yml
@@ -26,5 +26,4 @@
         name: crond
         enabled: true
         state: started
-      failed_when: false
       when: ansible_facts['os_family'] == 'Archlinux'

--- a/ansible/roles/timezone/molecule/docker/prepare.yml
+++ b/ansible/roles/timezone/molecule/docker/prepare.yml
@@ -16,9 +16,15 @@
         state: present
       when: ansible_facts['os_family'] == 'Archlinux'
 
+    - name: Reload systemd after cronie install (Archlinux only)
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+
     - name: Enable and start crond (Archlinux only)
       ansible.builtin.service:
         name: crond
         enabled: true
         state: started
+      failed_when: false
       when: ansible_facts['os_family'] == 'Archlinux'

--- a/ansible/roles/timezone/molecule/docker/prepare.yml
+++ b/ansible/roles/timezone/molecule/docker/prepare.yml
@@ -21,9 +21,9 @@
         daemon_reload: true
       when: ansible_facts['os_family'] == 'Archlinux'
 
-    - name: Enable and start crond (Archlinux only)
+    - name: Enable and start cronie (Archlinux only)
       ansible.builtin.service:
-        name: crond
+        name: cronie
         enabled: true
         state: started
       when: ansible_facts['os_family'] == 'Archlinux'

--- a/ansible/roles/timezone/molecule/docker/prepare.yml
+++ b/ansible/roles/timezone/molecule/docker/prepare.yml
@@ -1,16 +1,24 @@
 ---
-- name: Prepare
+- name: Bootstrap Docker container
+  ansible.builtin.import_playbook: ../../../../molecule/shared/prepare-docker.yml
+
+- name: Prepare (timezone-specific)
   hosts: all
   become: true
   gather_facts: true
   tasks:
-    - name: Update pacman cache (Archlinux)
+    # Cron installed ONLY on Archlinux to test both handler paths:
+    #   Arch: cron present → handler fires → verify cron running
+    #   Ubuntu: cron absent → handler skips gracefully
+    - name: Install cron for handler testing (Archlinux only)
       community.general.pacman:
-        update_cache: true
+        name: cronie
+        state: present
       when: ansible_facts['os_family'] == 'Archlinux'
 
-    - name: Update apt cache (Debian/Ubuntu)
-      ansible.builtin.apt:
-        update_cache: true
-        cache_valid_time: 3600
-      when: ansible_facts['os_family'] == 'Debian'
+    - name: Enable and start crond (Archlinux only)
+      ansible.builtin.service:
+        name: crond
+        enabled: true
+        state: started
+      when: ansible_facts['os_family'] == 'Archlinux'

--- a/ansible/roles/timezone/molecule/shared/verify.yml
+++ b/ansible/roles/timezone/molecule/shared/verify.yml
@@ -74,6 +74,45 @@
           not found in installed packages
       when: timezone_packages_tzdata is defined
 
+    # ---- cron handler: service running when present ----
+    # Docker: cron on Arch (handler fires), absent on Ubuntu (handler skips)
+    # Vagrant/default: cron may or may not be installed — assertion conditional
+
+    - name: Gather service facts for cron check
+      ansible.builtin.service_facts:
+
+    - name: Determine expected cron service name
+      ansible.builtin.set_fact:
+        _timezone_verify_cron_name: >-
+          {{ 'crond' if ansible_facts['os_family'] in ['Archlinux', 'RedHat', 'Void', 'Gentoo'] else 'cron' }}
+
+    - name: Assert cron service is running (when present)
+      ansible.builtin.assert:
+        that:
+          - >-
+            ansible_facts.services[_timezone_verify_cron_name ~ '.service']['state'] == 'running'
+        fail_msg: >-
+          Cron service '{{ _timezone_verify_cron_name }}' expected running,
+          got {{ ansible_facts.services.get(_timezone_verify_cron_name ~ '.service', {}).get('state', 'not found') }}
+      when:
+        - (_timezone_verify_cron_name ~ '.service') in ansible_facts.services
+
+    - name: Show cron handler skip (when absent)
+      ansible.builtin.debug:
+        msg: "Cron service '{{ _timezone_verify_cron_name }}' not installed — handler skip path confirmed"
+      when:
+        - (_timezone_verify_cron_name ~ '.service') not in ansible_facts.services
+        - _timezone_verify_cron_name not in ansible_facts.services
+
+    # ---- timezone_packages_tzdata undefined path ----
+
+    - name: Show tzdata variable status
+      ansible.builtin.debug:
+        msg: >-
+          timezone_packages_tzdata is {{ 'defined' if timezone_packages_tzdata is defined else 'undefined' }}
+          — {{ 'tzdata install was executed' if timezone_packages_tzdata is defined
+               else 'tzdata install was skipped (expected)' }}
+
     # ---- /etc/timezone file (Debian/Ubuntu, non-systemd only) ----
     # NOTE: community.general.timezone on systemd hosts uses timedatectl
     # which updates /etc/localtime but does NOT update /etc/timezone.
@@ -116,6 +155,37 @@
     - name: Show timezone abbreviation from date
       ansible.builtin.debug:
         msg: "System date reports timezone abbreviation: {{ _timezone_verify_date_output.stdout }}"
+
+    # ---- timezone name validation ----
+
+    - name: Assert timezone zone file exists in tz database
+      ansible.builtin.stat:
+        path: "/usr/share/zoneinfo/{{ timezone_name }}"
+      register: _timezone_verify_zoneinfo
+
+    - name: Assert timezone_name is valid
+      ansible.builtin.assert:
+        that:
+          - _timezone_verify_zoneinfo.stat.exists
+        fail_msg: "Timezone '{{ timezone_name }}' not found in /usr/share/zoneinfo/"
+
+    # ---- negative test: invalid timezone rejected ----
+    # No check_mode — module validates timezone name against tz database
+    # and fails BEFORE making any state change. Invalid name does not
+    # exist in /usr/share/zoneinfo/ so module fails at validation,
+    # never touching /etc/localtime.
+
+    - name: Attempt to set invalid timezone (negative test)
+      community.general.timezone:
+        name: "Invalid/NotATimezone"
+      register: _timezone_verify_invalid
+      ignore_errors: true
+
+    - name: Assert invalid timezone is rejected
+      ansible.builtin.assert:
+        that:
+          - _timezone_verify_invalid is failed
+        fail_msg: "Invalid timezone was NOT rejected by the timezone module"
 
     # ---- Summary ----
 

--- a/ansible/roles/timezone/molecule/vagrant/molecule.yml
+++ b/ansible/roles/timezone/molecule/vagrant/molecule.yml
@@ -30,7 +30,7 @@ provisioner:
       all:
         timezone_name: "Asia/Almaty"
         timezone_packages_tzdata:
-          Gentoo: "timezone-data"
+          Gentoo: "sys-libs/timezone-data"
           default: "tzdata"
   playbooks:
     prepare: prepare.yml

--- a/ansible/roles/timezone/tasks/main.yml
+++ b/ansible/roles/timezone/tasks/main.yml
@@ -2,7 +2,30 @@
 # === Таймзона ===
 # Установка системной таймзоны
 # Дистро-агностик, инит-агностик
-# Действие → Проверка → Логирование
+# Preflight → Действие → Проверка → Логирование
+
+# ======================================================================
+# ---- Preflight (ROLE-003) ----
+# ======================================================================
+
+- name: Assert supported operating system
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['os_family'] in _timezone_supported_os
+    fail_msg: >-
+      OS family '{{ ansible_facts['os_family'] }}' is not supported.
+      Supported: {{ _timezone_supported_os | join(', ') }}
+    success_msg: "OS family '{{ ansible_facts['os_family'] }}' is supported"
+  tags: ['timezone']
+
+- name: Assert timezone_name is defined and non-empty
+  ansible.builtin.assert:
+    that:
+      - timezone_name is defined
+      - timezone_name | length > 0
+    fail_msg: "timezone_name must be a non-empty string (e.g., 'UTC', 'America/New_York')"
+    success_msg: "timezone_name = '{{ timezone_name }}'"
+  tags: ['timezone']
 
 # ======================================================================
 # ---- Установка tzdata ----
@@ -15,6 +38,20 @@
   when: timezone_packages_tzdata is defined
   tags: ['timezone']
 
+- name: "Report: Install tzdata"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_timezone_phases"
+    common_rpt_phase: "Install tzdata"
+    common_rpt_detail: >-
+      {{ (timezone_packages_tzdata[ansible_facts['os_family']]
+          | default(timezone_packages_tzdata.get('default', 'tzdata')))
+         if timezone_packages_tzdata is defined else 'skipped' }}
+    common_rpt_status: "{{ 'skip' if timezone_packages_tzdata is not defined else 'done' }}"
+  tags: ['timezone', 'report']
+
 # ======================================================================
 # ---- Установка таймзоны ----
 # ======================================================================
@@ -26,24 +63,19 @@
   tags: ['timezone']
 
 # ======================================================================
-# ---- Проверка ----
+# ---- Проверка (ROLE-005) ----
 # ======================================================================
 
-- name: Verify timezone symlink
-  ansible.builtin.command: readlink -f /etc/localtime
-  register: timezone_check
-  changed_when: false
+- name: Flush handlers before verification
+  ansible.builtin.meta: flush_handlers
   tags: ['timezone']
 
-- name: Assert timezone matches expected value
-  ansible.builtin.assert:
-    that: timezone_name in timezone_check.stdout
-    fail_msg: "Timezone mismatch: got '{{ timezone_check.stdout }}', expected '{{ timezone_name }}'"
-    quiet: true
+- name: Verify timezone
+  ansible.builtin.include_tasks: verify.yml
   tags: ['timezone']
 
 # ======================================================================
-# ---- Отчёт ----
+# ---- Отчёт (ROLE-008) ----
 # ======================================================================
 
 - name: "Report: Set timezone"

--- a/ansible/roles/timezone/tasks/verify.yml
+++ b/ansible/roles/timezone/tasks/verify.yml
@@ -1,0 +1,35 @@
+---
+# === Таймзона — in-role verification (ROLE-005) ===
+
+- name: Verify timezone symlink
+  ansible.builtin.command: readlink -f /etc/localtime
+  register: _timezone_verify_symlink
+  changed_when: false
+  tags: ['timezone']
+
+- name: Assert timezone matches expected value
+  ansible.builtin.assert:
+    that:
+      - timezone_name in _timezone_verify_symlink.stdout
+    fail_msg: "Timezone mismatch: got '{{ _timezone_verify_symlink.stdout }}', expected '{{ timezone_name }}'"
+    quiet: true
+  tags: ['timezone']
+
+- name: Verify timezone via timedatectl (systemd only)
+  ansible.builtin.command: timedatectl show --property=Timezone --value
+  register: _timezone_verify_timedatectl
+  changed_when: false
+  failed_when: false
+  when: ansible_facts['service_mgr'] == 'systemd'
+  tags: ['timezone']
+
+- name: Assert timedatectl agrees with expected timezone (systemd only)
+  ansible.builtin.assert:
+    that:
+      - _timezone_verify_timedatectl.stdout == timezone_name
+    fail_msg: "timedatectl reports '{{ _timezone_verify_timedatectl.stdout }}', expected '{{ timezone_name }}'"
+    quiet: true
+  when:
+    - ansible_facts['service_mgr'] == 'systemd'
+    - _timezone_verify_timedatectl.rc == 0
+  tags: ['timezone']

--- a/ansible/roles/timezone/vars/main.yml
+++ b/ansible/roles/timezone/vars/main.yml
@@ -5,7 +5,6 @@
 timezone_cron_service:
   Archlinux: crond
   Debian: cron
-  Ubuntu: cron
   RedHat: crond
   Void: crond
   Gentoo: crond


### PR DESCRIPTION
## Summary

- **Task 1**: Create shared `molecule/shared/prepare-docker.yml` (DRY parity with Vagrant)
- **Task 2**: Already done — `packages_tzdata` → `timezone_packages_tzdata` rename
- **Task 3**: Fix Gentoo package name `sys-libs/timezone-data` in 3 molecule configs
- **Task 4**: Remove dead `Ubuntu: cron` entry from `vars/main.yml`
- **Task 5**: Full `tasks/main.yml` rewrite — ROLE-003 preflight + ROLE-005 `verify.yml` + ROLE-008 report phases + `timezone_name` input validation + `timedatectl` in-role verify + `flush_handlers`
- **Task 5+**: Fix stale variable name in `meta/main.yml` (brainstorm finding)
- **Task 6**: Platform-differentiated Docker testing — Arch gets cron + tzdata, Ubuntu gets neither
- **Task 7**: Expand molecule `shared/verify.yml` — cron handler, undefined var, zoneinfo validation, negative test
- **Task 8**: README rewrite — document all ROLE-003/005/008 compliance

## Test plan

- [ ] `molecule test -s docker` passes on remote VM (Arch + Ubuntu systemd containers)
- [ ] Idempotence check passes (no changed tasks on second converge)
- [ ] CI workflow passes (if triggered)
- [ ] Verify preflight assert rejects unsupported OS
- [ ] Verify `timezone_name` validation rejects empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)