### PR TITLE
fix(hostctl): bug fixes and code cleanup

### DIFF
--- a/ansible/roles/hostctl/molecule/default/molecule.yml
+++ b/ansible/roles/hostctl/molecule/default/molecule.yml
@@ -9,6 +9,8 @@ platforms:
 
 provisioner:
   name: ansible
+  options:
+    extra-vars: "hostctl_version=1.1.4"
   config_options:
     defaults:
       callbacks_enabled: profile_tasks

--- a/ansible/roles/hostctl/molecule/docker/molecule.yml
+++ b/ansible/roles/hostctl/molecule/docker/molecule.yml
@@ -34,6 +34,7 @@ provisioner:
   name: ansible
   options:
     skip-tags: report
+    extra-vars: "hostctl_version=1.1.4"
   env:
     ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
   config_options:

--- a/ansible/roles/hostctl/molecule/shared/converge.yml
+++ b/ansible/roles/hostctl/molecule/shared/converge.yml
@@ -15,3 +15,15 @@
             - { ip: "127.0.0.1", host: "api.local" }
           registry:
             - { ip: "172.17.0.1", host: "registry.local" }
+
+- name: Converge — empty profiles
+  hosts: all
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: hostctl
+      vars:
+        hostctl_version: "1.1.4"
+        hostctl_verify_checksum: true
+        hostctl_profiles: {}

--- a/ansible/roles/hostctl/molecule/shared/verify.yml
+++ b/ansible/roles/hostctl/molecule/shared/verify.yml
@@ -6,7 +6,6 @@
 
   vars:
     verify_binary: /usr/local/bin/hostctl
-    verify_version_string: "1.1.4"
     verify_profiles:
       - name: dev
         entries:
@@ -42,8 +41,9 @@
 
     - name: Assert hostctl version matches expected
       ansible.builtin.assert:
-        that: verify_version_string in _hostctl_verify_version.stdout
-        fail_msg: "Expected '{{ verify_version_string }}' in: {{ _hostctl_verify_version.stdout }}"
+        that: hostctl_version in _hostctl_verify_version.stdout
+        fail_msg: "Expected '{{ hostctl_version }}' in: {{ _hostctl_verify_version.stdout }}"
+      when: hostctl_version is defined
 
     # ---- Profile directory ----
 

--- a/ansible/roles/hostctl/molecule/vagrant/molecule.yml
+++ b/ansible/roles/hostctl/molecule/vagrant/molecule.yml
@@ -20,6 +20,7 @@ provisioner:
   name: ansible
   options:
     skip-tags: report,aur,molecule-notest
+    extra-vars: "hostctl_version=1.1.4"
   config_options:
     defaults:
       callbacks_enabled: profile_tasks

--- a/ansible/roles/hostctl/tasks/download.yml
+++ b/ansible/roles/hostctl/tasks/download.yml
@@ -1,6 +1,5 @@
 ---
 # === hostctl — download binary from GitHub releases ===
-# Fallback when package manager did not install hostctl.
 # Uses block/always to guarantee cleanup of temp files on success and failure.
 
 - name: Install hostctl from GitHub releases
@@ -8,27 +7,16 @@
 
     # ---- Resolve version ----
 
-    - name: Query latest hostctl release from GitHub API
+    - name: Query hostctl release from GitHub API
       ansible.builtin.uri:
-        url: "{{ hostctl_github_api }}/repos/{{ hostctl_github_repo }}/releases/latest"
+        url: >-
+          {{ hostctl_github_api }}/repos/{{ hostctl_github_repo }}/releases/{{
+            (hostctl_version == 'latest') | ternary('latest', 'tags/v' ~ (hostctl_version | regex_replace('^v', '')))
+          }}
         return_content: true
         headers:
-          Accept: application/vnd.github.v3+json
+          Accept: application/vnd.github+json
       register: hostctl_release
-      when: hostctl_version == "latest"
-
-    - name: Query specific hostctl release from GitHub API
-      ansible.builtin.uri:
-        url: "{{ hostctl_github_api }}/repos/{{ hostctl_github_repo }}/releases/tags/v{{ hostctl_version | regex_replace('^v', '') }}"
-        return_content: true
-        headers:
-          Accept: application/vnd.github.v3+json
-      register: hostctl_release_pinned
-      when: hostctl_version != "latest"
-
-    - name: Set hostctl release facts
-      ansible.builtin.set_fact:
-        hostctl_release_data: "{{ (hostctl_version == 'latest') | ternary(hostctl_release, hostctl_release_pinned) }}"
 
     # ---- Map architecture ----
 
@@ -47,24 +35,24 @@
 
     - name: Find tarball asset URL
       ansible.builtin.set_fact:
-        hostctl_tarball_url: >
-          {{ hostctl_release_data.json.assets
+        hostctl_tarball_url: >-
+          {{ hostctl_release.json.assets
              | selectattr('name', 'match', '.*linux_' ~ hostctl_arch ~ '\.tar\.gz$')
              | map(attribute='browser_download_url')
-             | first }}
-        hostctl_tarball_name: >
-          {{ hostctl_release_data.json.assets
+             | first | trim }}
+        hostctl_tarball_name: >-
+          {{ hostctl_release.json.assets
              | selectattr('name', 'match', '.*linux_' ~ hostctl_arch ~ '\.tar\.gz$')
              | map(attribute='name')
-             | first }}
+             | first | trim }}
 
     - name: Find checksums asset URL
       ansible.builtin.set_fact:
-        hostctl_checksums_url: >
-          {{ hostctl_release_data.json.assets
+        hostctl_checksums_url: >-
+          {{ hostctl_release.json.assets
              | selectattr('name', 'match', '.*checksum.*')
              | map(attribute='browser_download_url')
-             | first | default('') }}
+             | first | default('') | trim }}
 
     # ---- Checksum verification ----
 
@@ -86,28 +74,24 @@
 
     - name: Extract SHA256 checksum for target asset
       ansible.builtin.set_fact:
-        hostctl_checksum: >
+        hostctl_checksum: >-
           sha256:{{ hostctl_checksums.content
-             | regex_search('([a-f0-9]{64})\s+' ~ hostctl_tarball_name, '\1')
+             | trim
+             | splitlines
+             | select('search', hostctl_tarball_name)
+             | first
+             | split(' ')
              | first }}
       when: hostctl_checksums is not skipped
 
     # ---- Download archive ----
 
-    - name: Download hostctl archive (with checksum)
+    - name: Download hostctl archive
       ansible.builtin.get_url:
         url: "{{ hostctl_tarball_url }}"
         dest: /tmp/hostctl.tar.gz
-        checksum: "{{ hostctl_checksum }}"
+        checksum: "{{ hostctl_checksum | default(omit) }}"
         mode: '0644'
-      when: hostctl_checksum is defined
-
-    - name: Download hostctl archive (no checksum available)
-      ansible.builtin.get_url:
-        url: "{{ hostctl_tarball_url }}"
-        dest: /tmp/hostctl.tar.gz
-        mode: '0644'
-      when: hostctl_checksum is not defined
 
     - name: Verify archive was downloaded
       ansible.builtin.stat:

--- a/ansible/roles/hostctl/tasks/install.yml
+++ b/ansible/roles/hostctl/tasks/install.yml
@@ -1,12 +1,12 @@
 ---
 # === hostctl — installation ===
-# Strategy: package manager (non-Arch) → AUR (Arch) → GitHub releases fallback
+# Strategy: GitHub releases (sole install method).
 # Idempotent: skips re-download if pinned version already installed.
 
 # ---- Version idempotency check ----
 
 - name: Get installed hostctl version
-  ansible.builtin.command: "{{ hostctl_install_dir }}/hostctl --version"
+  ansible.builtin.command: hostctl --version
   register: hostctl_installed_ver
   changed_when: false
   failed_when: false
@@ -22,69 +22,25 @@
     msg: "hostctl {{ hostctl_version }} already installed — skipping"
   when: hostctl_skip_install | bool
 
-# ---- Package manager install (non-Arch) ----
+# ---- GitHub releases install ----
 
-- name: Install hostctl via package manager
-  ansible.builtin.package:
-    name: hostctl
-    state: present
-  when:
-    - not (hostctl_skip_install | bool)
-    - ansible_facts['os_family'] not in ['Archlinux']
-  register: hostctl_pkg
-  failed_when: false
-
-- name: "Report: hostctl package install result"
-  ansible.builtin.debug:
-    msg: >-
-      hostctl package install {{ 'succeeded' if (hostctl_pkg is not failed) else 'failed — will try GitHub fallback.' }}
-  when:
-    - hostctl_pkg is defined
-    - not (hostctl_pkg is skipped)
-
-# ---- AUR install (Arch Linux) ----
-
-- name: Install hostctl via AUR (Arch Linux)
-  kewlfft.aur.aur:
-    name: hostctl-bin
-    use: yay
-    state: present
-  become: true
-  become_user: "{{ yay_build_user | default('aur_builder') }}"
-  failed_when: false
-  when:
-    - not (hostctl_skip_install | bool)
-    - ansible_facts['os_family'] == 'Archlinux'
-  tags: ['hostctl', 'molecule-notest']
-
-# ---- GitHub fallback ----
-
-- name: Check if hostctl available after package/AUR install
-  ansible.builtin.command: command -v hostctl
-  register: hostctl_which
-  changed_when: false
-  failed_when: false
-  when: not (hostctl_skip_install | bool)
-
-- name: Install hostctl from GitHub releases (fallback)
+- name: Install hostctl from GitHub releases
   ansible.builtin.include_tasks: download.yml
   when:
     - not (hostctl_skip_install | bool)
-    - hostctl_which.rc | default(1) != 0
     - not ansible_check_mode
 
-- name: "Note: hostctl GitHub download skipped in check mode"
+- name: "Note: hostctl download skipped in check mode"
   ansible.builtin.debug:
-    msg: "hostctl GitHub download skipped — running in check mode"
+    msg: "hostctl download skipped — running in check mode"
   when:
     - not (hostctl_skip_install | bool)
-    - hostctl_which.rc | default(1) != 0
     - ansible_check_mode
 
 # ---- Final verification ----
 
 - name: Verify hostctl is installed and working
-  ansible.builtin.command: "{{ hostctl_install_dir }}/hostctl --version"
+  ansible.builtin.command: command -v hostctl
   register: hostctl_version_check
   changed_when: false
   failed_when: hostctl_version_check.rc != 0


### PR DESCRIPTION
## Summary

- Remove dead package manager and AUR install paths; GitHub releases is now the sole install method (eliminates `kewlfft.aur` dependency and silent failure swallowing)
- Merge duplicate URI tasks into one with a conditional URL using `ternary()`
- Fix deprecated GitHub API Accept header (`application/vnd.github.v3+json` → `application/vnd.github+json`)
- Add `| trim` to all asset URL facts to prevent YAML `>` block scalar trailing whitespace breakage; switch block scalars to `>-`
- Replace fragile `regex_search` for SHA256 checksum extraction with `splitlines | select | first | split | first`
- Merge two conditional download tasks into one via `checksum: "{{ hostctl_checksum | default(omit) }}"`
- Fix final verify in `install.yml` to use `command -v hostctl` instead of hardcoded `{{ hostctl_install_dir }}/hostctl`
- Remove hardcoded `verify_version_string` from `verify.yml` vars; pass `hostctl_version` via molecule `extra-vars` in all three molecule configs
- Add empty profiles play to `converge.yml` to cover the `hostctl_profiles: {}` edge case

Closes #65

## Test plan

- [ ] `molecule test -s docker` passes on Arch and Ubuntu platforms
- [ ] `molecule test -s vagrant` passes on arch-vm and ubuntu-base platforms
- [ ] Idempotence check passes (no changes on second run)
- [ ] Version assertion in verify.yml uses `hostctl_version` from extra-vars correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)