### PR TITLE
fix(hostctl): use .splitlines() and restore install_dir verify

### DIFF
--- a/ansible/roles/hostctl/tasks/download.yml
+++ b/ansible/roles/hostctl/tasks/download.yml
@@ -75,8 +75,10 @@
     - name: Extract SHA256 checksum for target asset
       ansible.builtin.set_fact:
         hostctl_checksum: >-
-          sha256:{{ hostctl_checksums.content
-             | regex_search('([a-f0-9]{64})\s+' ~ hostctl_tarball_name, '\1')
+          sha256:{{ hostctl_checksums.content.splitlines()
+             | select('search', hostctl_tarball_name)
+             | first
+             | split(' ')
              | first }}
       when: hostctl_checksums is not skipped
 

--- a/ansible/roles/hostctl/tasks/install.yml
+++ b/ansible/roles/hostctl/tasks/install.yml
@@ -40,7 +40,7 @@
 # ---- Final verification ----
 
 - name: Verify hostctl is installed and working
-  ansible.builtin.command: hostctl --version
+  ansible.builtin.command: "{{ hostctl_install_dir }}/hostctl --version"
   register: hostctl_version_check
   changed_when: false
   failed_when: hostctl_version_check.rc != 0


### PR DESCRIPTION
## Summary
- Replace `regex_search` with `.splitlines()` for checksum extraction — handles all line ending styles
- Restore `{{ hostctl_install_dir }}/hostctl --version` in final verify — AUR removed, path is always known

## Context
Follow-up to #102. `split('\n')` failed in CI (likely `\r\n` content from GitHub API), `regex_search` was a workaround. `.splitlines()` is the correct fix per Python/Jinja2 semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)