### PR TITLE
fix(gpu_drivers): resolve remaining compliance gaps (ROLE-002/004/014, TEST-010/011/012)

### DIFF
--- a/ansible/roles/gpu_drivers/defaults/main.yml
+++ b/ansible/roles/gpu_drivers/defaults/main.yml
@@ -31,6 +31,14 @@ gpu_drivers_nvidia_blacklist_nouveau: true # blacklist nouveau (proprietary/open
 gpu_drivers_manage_initramfs: true        # regenerate initramfs after driver install
 gpu_drivers_nvidia_suspend: true          # enable nvidia-suspend/hibernate/resume.service (systemd only)
 
+# ---- Security management (ROLE-004) ----
+# Master toggle for security-hardening tasks: KMS modeset enforcement and nouveau blacklisting.
+# Tags: security, gpu_security_kms (KMS), gpu_security_blacklist (module blacklist).
+# CIS mapping: closest benchmark is kernel module restriction (analogous to CIS 3.5 series);
+# no direct GPU CIS/STIG control exists — these are workstation hardening best practices.
+# Set to false only in environments where NVIDIA proprietary drivers must coexist with nouveau.
+gpu_drivers_manage_security: true
+
 # ---- NVIDIA modprobe options (ROLE-010) ----
 # NVreg_PreserveVideoMemoryAllocations=1 is required for stable suspend/resume with NVIDIA.
 # Set to 0 to disable if not using suspend or if causing issues with older cards.

--- a/ansible/roles/gpu_drivers/handlers/main.yml
+++ b/ansible/roles/gpu_drivers/handlers/main.yml
@@ -2,11 +2,17 @@
 # Handlers for gpu_drivers role
 
 # ---- Initramfs regeneration (init-agnostic via listen:) ----
+# changed_when: true is intentional — these commands always regenerate the
+# initramfs image when they run; no "already up to date" exit code exists for
+# mkinitcpio, dracut, or update-initramfs.
+# Idempotence is preserved at the notify level: handlers only fire when a
+# config template task reports changed. On a second run with no config changes
+# no task notifies the handler, so it never executes and changed=0.
 
 - name: Regenerate initramfs (mkinitcpio)
   ansible.builtin.command: mkinitcpio -P
   listen: "regenerate initramfs"
-  changed_when: true
+  changed_when: true  # always produces a new image when it runs — see comment above
   when:
     - gpu_drivers_initramfs_tool is defined
     - gpu_drivers_initramfs_tool == 'mkinitcpio'
@@ -14,7 +20,7 @@
 - name: Regenerate initramfs (dracut)
   ansible.builtin.command: dracut --force
   listen: "regenerate initramfs"
-  changed_when: true
+  changed_when: true  # always produces a new image when it runs — see comment above
   when:
     - gpu_drivers_initramfs_tool is defined
     - gpu_drivers_initramfs_tool == 'dracut'
@@ -22,7 +28,7 @@
 - name: Regenerate initramfs (initramfs-tools)
   ansible.builtin.command: update-initramfs -u -k all
   listen: "regenerate initramfs"
-  changed_when: true
+  changed_when: true  # always produces a new image when it runs — see comment above
   when:
     - gpu_drivers_initramfs_tool is defined
     - gpu_drivers_initramfs_tool == 'initramfs-tools'

--- a/ansible/roles/gpu_drivers/molecule/docker/molecule.yml
+++ b/ansible/roles/gpu_drivers/molecule/docker/molecule.yml
@@ -3,6 +3,7 @@ driver:
   name: docker
 
 platforms:
+  # ---- Happy path: Intel vendor, VA-API enabled ----
   - name: Archlinux-systemd
     image: "${MOLECULE_ARCH_IMAGE:-ghcr.io/textyre/arch-base:latest}"
     pre_build_image: true
@@ -33,6 +34,38 @@ platforms:
       - 8.8.8.8
       - 8.8.4.4
 
+  # ---- Edge case: vendor=none (no GPU, role must skip all driver tasks) ----
+  - name: Archlinux-vendor-none
+    image: "${MOLECULE_ARCH_IMAGE:-ghcr.io/textyre/arch-base:latest}"
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
+  # ---- Edge case: vaapi=false (Intel GPU present but VA-API disabled, gpu.conf must be absent) ----
+  - name: Ubuntu-vaapi-off
+    image: "${MOLECULE_UBUNTU_IMAGE:-ghcr.io/textyre/ubuntu-base:latest}"
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
 provisioner:
   name: ansible
   options:
@@ -42,6 +75,25 @@ provisioner:
   config_options:
     defaults:
       callbacks_enabled: profile_tasks
+  # Per-host vars drive both converge and verify — no hardcoded vendor in playbooks (TEST-011/ROLE-014)
+  inventory:
+    host_vars:
+      Archlinux-systemd:
+        gpu_drivers_vendor: intel
+        gpu_drivers_vaapi: true
+        gpu_drivers_vulkan_tools: true
+      Ubuntu-systemd:
+        gpu_drivers_vendor: intel
+        gpu_drivers_vaapi: true
+        gpu_drivers_vulkan_tools: true
+      Archlinux-vendor-none:
+        gpu_drivers_vendor: none
+        gpu_drivers_vaapi: false
+        gpu_drivers_vulkan_tools: false
+      Ubuntu-vaapi-off:
+        gpu_drivers_vendor: intel
+        gpu_drivers_vaapi: false
+        gpu_drivers_vulkan_tools: true
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml

--- a/ansible/roles/gpu_drivers/molecule/shared/converge.yml
+++ b/ansible/roles/gpu_drivers/molecule/shared/converge.yml
@@ -18,6 +18,6 @@
         manager: auto
 
   roles:
+    # vars come from molecule.yml provisioner.inventory.host_vars per host (TEST-011/ROLE-014).
+    # Each platform defines gpu_drivers_vendor, gpu_drivers_vaapi, gpu_drivers_vulkan_tools.
     - role: gpu_drivers
-      vars:
-        gpu_drivers_vendor: intel

--- a/ansible/roles/gpu_drivers/molecule/shared/verify.yml
+++ b/ansible/roles/gpu_drivers/molecule/shared/verify.yml
@@ -1,26 +1,31 @@
 ---
 # Shared verify playbook for gpu_drivers molecule scenarios.
-# Designed for the Intel vendor path (gpu_drivers_vendor: intel, pure Mesa, no DKMS).
+# Covers multiple paths via per-host vars set in molecule.yml provisioner.inventory.host_vars:
+#   - Intel vendor, VA-API enabled  (Archlinux-systemd, Ubuntu-systemd)
+#   - vendor=none                   (Archlinux-vendor-none) — no packages/configs
+#   - Intel vendor, VA-API disabled (Ubuntu-vaapi-off) — packages installed, gpu.conf absent
+#   - Vagrant: Intel vendor, VA-API enabled (arch-vm, ubuntu-base) — default fallback
 #
 # Checks:
-#   - Intel driver packages installed (OS-aware names)
-#   - vulkan-tools installed
-#   - /etc/environment.d/gpu.conf exists with correct content and permissions
+#   - Intel driver packages installed (OS-aware names) — when vendor=intel
+#   - vulkan-tools installed — when vendor!=none and vulkan_tools enabled
+#   - /etc/environment.d/gpu.conf presence/absence based on vaapi flag and vendor
 #   - NVIDIA-specific configs are ABSENT (negative path)
 #   - /etc/modprobe.d/ directory exists
 #   - Hardware-dependent checks (lspci, vulkaninfo) — guarded for Docker
 #
 # Register variables follow ROLE-006: _gpu_drivers_verify_<check>
 
-- name: Verify gpu_drivers role (Intel path)
+- name: Verify gpu_drivers role
   hosts: all
   become: true
   gather_facts: true
   vars:
-    # Mirror the converge override — vendor facts derive from this
-    gpu_drivers_vendor: intel
-    gpu_drivers_vaapi: true
-    gpu_drivers_vulkan_tools: true
+    # Read per-host vars set in molecule.yml provisioner.inventory.host_vars (TEST-011/ROLE-014).
+    # Defaults preserve the original Intel happy-path for vagrant scenario backward compatibility.
+    gpu_drivers_vendor: "{{ hostvars[inventory_hostname]['gpu_drivers_vendor'] | default('intel') }}"
+    gpu_drivers_vaapi: "{{ hostvars[inventory_hostname]['gpu_drivers_vaapi'] | default(true) }}"
+    gpu_drivers_vulkan_tools: "{{ hostvars[inventory_hostname]['gpu_drivers_vulkan_tools'] | default(true) }}"
 
   tasks:
 

--- a/ansible/roles/gpu_drivers/molecule/vagrant/molecule.yml
+++ b/ansible/roles/gpu_drivers/molecule/vagrant/molecule.yml
@@ -25,6 +25,18 @@ provisioner:
   config_options:
     defaults:
       callbacks_enabled: profile_tasks
+  # Vagrant platforms use the Intel happy-path (defaults in verify.yml).
+  # Edge case platforms (vendor=none, vaapi=false) are covered by the Docker scenario.
+  inventory:
+    host_vars:
+      arch-vm:
+        gpu_drivers_vendor: intel
+        gpu_drivers_vaapi: true
+        gpu_drivers_vulkan_tools: true
+      ubuntu-base:
+        gpu_drivers_vendor: intel
+        gpu_drivers_vaapi: true
+        gpu_drivers_vulkan_tools: true
   playbooks:
     prepare: prepare.yml
     converge: ../shared/converge.yml

--- a/ansible/roles/gpu_drivers/requirements.yml
+++ b/ansible/roles/gpu_drivers/requirements.yml
@@ -1,0 +1,7 @@
+---
+# Role dependencies for gpu_drivers (TEST-010).
+# The 'common' role is used via include_role for report_phase and report_render.
+# Resolution: molecule provisioner sets ANSIBLE_ROLES_PATH="${MOLECULE_PROJECT_DIRECTORY}/../"
+# so galaxy install is not required — the role is accessed directly from the source tree.
+roles:
+  - name: common

--- a/ansible/roles/gpu_drivers/tasks/configure.yml
+++ b/ansible/roles/gpu_drivers/tasks/configure.yml
@@ -3,6 +3,10 @@
 # SRP: only deploys config files (modprobe.d, environment.d) and enables services; never installs packages.
 
 # ---- NVIDIA: DRM KMS modprobe options ----
+# Security: nvidia-drm.modeset=1 enables kernel mode setting required for Wayland DRM leasing
+# and prevents display buffer access without DRM authentication (workstation security best practice,
+# analogous to CIS 3.5 kernel module hardening). Controlled by gpu_drivers_manage_security.
+# Tags: security, gpu_security_kms
 
 - name: Deploy NVIDIA DRM KMS modprobe options
   ansible.builtin.template:
@@ -13,10 +17,11 @@
     mode: '0644'
   notify: regenerate initramfs
   when:
+    - gpu_drivers_manage_security | bool
     - gpu_drivers_has_nvidia
     - gpu_drivers_nvidia_variant in ['proprietary', 'open-kernel']
     - gpu_drivers_nvidia_kms
-  tags: ['gpu', 'nvidia']
+  tags: ['gpu', 'nvidia', 'security', 'gpu_security_kms']
 
 - name: Remove NVIDIA modprobe options (not applicable)
   ansible.builtin.file:
@@ -29,6 +34,10 @@
   tags: ['gpu', 'nvidia']
 
 # ---- NVIDIA: blacklist nouveau ----
+# Security: blacklisting the nouveau kernel module when the proprietary driver is active prevents
+# module substitution and ensures only the intended driver manages the GPU.
+# Analogous to CIS 3.5.x (disable unused kernel modules). Controlled by gpu_drivers_manage_security.
+# Tags: security, gpu_security_blacklist
 
 - name: Deploy nouveau blacklist (proprietary/open-kernel)
   ansible.builtin.template:
@@ -38,10 +47,11 @@
     group: root
     mode: '0644'
   when:
+    - gpu_drivers_manage_security | bool
     - gpu_drivers_has_nvidia
     - gpu_drivers_nvidia_variant in ['proprietary', 'open-kernel']
     - gpu_drivers_nvidia_blacklist_nouveau
-  tags: ['gpu', 'nvidia']
+  tags: ['gpu', 'nvidia', 'security', 'gpu_security_blacklist']
 
 - name: Remove nouveau blacklist (not applicable)
   ansible.builtin.file:
@@ -54,6 +64,10 @@
   tags: ['gpu', 'nvidia']
 
 # ---- NVIDIA: suspend/resume systemd services ----
+# ROLE-002: these services are systemd-specific; guarded by service_mgr check.
+# Non-systemd init systems (runit, openrc, s6, dinit) do not use systemd service units.
+# GPU kernel module suspend/resume on non-systemd is handled by the init system's
+# power management hooks — no equivalent service management needed here.
 
 - name: Enable NVIDIA suspend/resume systemd services
   ansible.builtin.systemd:
@@ -100,6 +114,19 @@
       {{ 'skipped (NVIDIA active or non-systemd)' if _gpu_drivers_disable_nvidia_services is skipped
          else 'attempted (services may not exist if driver not installed)' }}
   when: _gpu_drivers_disable_nvidia_services is defined
+  tags: ['gpu', 'nvidia']
+
+# ROLE-002: note non-systemd path for NVIDIA suspend services.
+- name: Note NVIDIA suspend services skipped on non-systemd init
+  ansible.builtin.debug:
+    msg: >-
+      NVIDIA suspend/resume systemd service units are not managed on
+      {{ ansible_facts['service_mgr'] }} — power management hooks are
+      handled by the init system directly.
+  when:
+    - gpu_drivers_has_nvidia
+    - gpu_drivers_nvidia_suspend
+    - ansible_facts['service_mgr'] != 'systemd'
   tags: ['gpu', 'nvidia']
 
 # ---- VA-API environment variables ----

--- a/ansible/roles/gpu_drivers/tasks/verify.yml
+++ b/ansible/roles/gpu_drivers/tasks/verify.yml
@@ -124,7 +124,7 @@
   ansible.builtin.lineinfile:
     path: /etc/modprobe.d/nvidia.conf
     regexp: '^options nvidia-drm modeset='
-    line: "options nvidia-drm modeset=1"
+    line: "options nvidia-drm modeset={{ gpu_drivers_nvidia_kms | int }}"
     state: present
   check_mode: true
   register: _gpu_drivers_verify_modprobe_kms


### PR DESCRIPTION
## Summary

Resolves remaining compliance gaps from issue #80 audit that were not addressed in PR #111:

- **handlers**: document `changed_when: true` correctness for initramfs regeneration commands
- **requirements.yml**: declare `common` role dependency at role root (TEST-010)
- **edge case tests**: add `vendor=none` and `vaapi=false` Docker platforms (TEST-011); per-host vars via `provisioner.inventory.host_vars` in both docker and vagrant scenarios
- **no hardcoded vars**: `shared/converge.yml` and `shared/verify.yml` now read vars from host inventory instead of hardcoding `gpu_drivers_vendor: intel` (ROLE-014/TEST-012)
- **ROLE-004**: `gpu_drivers_manage_security` toggle; `security`, `gpu_security_kms`, `gpu_security_blacklist` tags on KMS and nouveau blacklist tasks; CIS mapping comment
- **ROLE-002**: explicit debug note when non-systemd init system is detected for NVIDIA suspend services path
- **ROLE-014**: fix hardcoded `modeset=1` in `tasks/verify.yml` → `gpu_drivers_nvidia_kms | int`

## Test plan

- [ ] `gpu_drivers (lint)` — yamllint + ansible-lint pass
- [ ] `gpu_drivers (test-docker)` — all 4 platforms converge + idempotence + verify pass (Archlinux-systemd, Ubuntu-systemd, Archlinux-vendor-none, Ubuntu-vaapi-off)
- [ ] `gpu_drivers (test-vagrant/arch)` and `(test-vagrant/ubuntu)` — unchanged Intel path passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)