### PR TITLE
fix(vm): resolve critical bugs and compliance gaps from audit #81

### DIFF
--- a/ansible/roles/vm/README.md
+++ b/ansible/roles/vm/README.md
@@ -1,104 +1,232 @@
-# Ansible Role: vm
+# vm
 
-Automatically detects and installs virtualization guest tools for VirtualBox, VMware, Hyper-V, and KVM environments.
+Detects the active hypervisor and installs matching guest tools (VirtualBox Guest Additions, open-vm-tools, Hyper-V Integration Services, QEMU Guest Agent).
 
-## Supported Hypervisors
+## Execution flow
 
-- **VirtualBox** - Guest Additions (package or ISO install with version enforcement)
-- **VMware** - open-vm-tools
-- **Hyper-V** - Integration Services
-- **KVM** - QEMU Guest Agent (qemu-guest-agent)
+1. **Assert OS support** — fails immediately on unsupported OS families (not in Archlinux/Debian/RedHat/Void/Gentoo)
+2. **Validate prerequisites** — asserts virtualization facts are available; fails if `gather_facts: false`
+3. **Load OS variables** (`vars/<OsFamily>.yml`) — loads distro-specific package names and service manager
+4. **Detect virtualization** — sets `vm_virt_type`, `vm_virt_role`, `vm_is_guest`, `vm_is_container`, `vm_hypervisor` from Ansible facts
+5. **Install guest tools** (`tasks/_install_guest_tools.yml`) — dispatches to hypervisor-specific task file:
+   - **VirtualBox** (`tasks/virtualbox.yml`): checks VBoxControl, installs packages, runs version detection (`virtualbox_version.yml`), triggers ISO install (`virtualbox_iso_install.yml`) on mismatch, checks LTS kernel DKMS (`virtualbox_lts_kernel.yml`), manages vboxservice/vboxadd-service, verifies kernel modules, checks X11 autostart, sets reboot flag
+   - **VMware** (`tasks/vmware.yml`): installs open-vm-tools, manages vmtoolsd/vgauthd, verifies vmw_balloon module, checks X11 autostart, reports version
+   - **Hyper-V** (`tasks/hyperv.yml`): installs hyperv package, manages hv_*_daemon services, verifies hv_vmbus module, sets reboot flag
+   - **KVM** (`tasks/kvm.yml`): installs qemu-guest-agent, manages service with virtio device guard, reports version
+   - Skips gracefully for containers/WSL2 (no guest tools needed)
+6. **Persist facts** (`tasks/_set_facts.yml`) — writes `/etc/ansible/facts.d/vm_guest.fact` (JSON with hypervisor, is_guest, is_container)
+7. **Verify** (`tasks/verify.yml`) — asserts fact file content is correct; checks environment variable sanity
+8. **Execution report** — writes structured report via `common/report_render.yml` with reboot_required footer
 
-## Requirements
+### Remove path (vm_state: absent)
 
-- Ansible 2.9 or higher
-- `gather_facts: true` (required for virtualization detection)
-- `become: true` (root privileges required for package installation and service management)
-- Supported OS families: Arch Linux, Debian/Ubuntu, Fedora/RHEL, Gentoo
+Steps 1–4 run normally, then `_remove_guest_tools.yml` removes packages and stops services for the detected hypervisor.
 
-## Role Variables
+### Handlers
 
-Available variables (see `defaults/main.yml`):
+| Handler | Triggered by | What it does |
+|---------|-------------|-------------|
+| `Restart virtualbox services` | VBox package install/update | Restarts vboxservice or vboxadd-service |
+| `Reload systemd daemon` | ISO service unit file creation | Runs `systemctl daemon-reload` (systemd only) |
 
-| Variable | Type | Default | Description |
-|----------|------|---------|-------------|
-| `packages_virtualbox_guest` | list | `[]` | VirtualBox guest packages to install |
-| `packages_vmware_guest` | list | `[]` | VMware guest packages to install |
-| `packages_hyperv_guest` | list | `[]` | Hyper-V guest packages to install |
-| `packages_kvm_guest` | list | `[]` | KVM/QEMU guest packages to install |
-| `vm_vbox_version_check` | bool | `true` | Enforce VirtualBox version match between host and guest |
-| `vm_vmware_version_report` | bool | `true` | Display VMware Tools version information |
-| `vm_kvm_version_report` | bool | `true` | Display QEMU Guest Agent version information |
+## Variables
+
+### Configurable (`defaults/main.yml`)
+
+Override via inventory (`group_vars/` or `host_vars/`), never edit `defaults/main.yml` directly.
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `vm_state` | `present` | safe | `present` installs guest tools, `absent` removes them |
+| `vm_packages_virtualbox_guest` | `['virtualbox-guest-utils']` | careful | VirtualBox guest packages. Change only to pin a specific version |
+| `vm_packages_vmware_guest` | `['open-vm-tools']` | careful | VMware guest packages |
+| `vm_packages_hyperv_guest` | `['hyperv']` | careful | Hyper-V packages (Arch: `hyperv`, Debian: `hyperv-daemons`) |
+| `vm_packages_kvm_guest` | `['qemu-guest-agent']` | careful | KVM/QEMU guest agent package |
+| `vm_vbox_version_check` | `true` | careful | When `true`, enforces host/guest VirtualBox version match. Triggers ISO install on mismatch. Set `false` to disable auto-upgrade |
+| `vm_vbox_lts_kernel_support` | OS-specific | careful | Set in `vars/<OsFamily>.yml`. When `true`, installs `virtualbox-guest-dkms` + `linux-lts-headers` for LTS kernels |
+| `vm_vmware_version_report` | `true` | safe | Display VMware Tools version in execution report |
+| `vm_kvm_version_report` | `true` | safe | Display QEMU Guest Agent version in execution report |
+
+### Internal mappings (`vars/`)
+
+These files map OS families to distro-specific values. Edit only when adding distro support.
+
+| File | What it contains | When to edit |
+|------|-----------------|-------------|
+| `vars/Archlinux.yml` | Package names, `vm_vbox_lts_kernel_support: true`, `vm_service_manager: systemd` | Adding Arch-specific packages |
+| `vars/Debian.yml` | Package names for Ubuntu/Debian, `hyperv-daemons` instead of `hyperv` | Adding Debian-specific packages |
+| `vars/RedHat.yml` | Package names for Fedora/RHEL, `hyperv-daemons` | Adding RHEL-specific packages |
+| `vars/Void.yml` | Package names for Void Linux, `vm_service_manager: runit` | Adding Void-specific packages |
+| `vars/Gentoo.yml` | Package names for Gentoo (`app-emulation/qemu-guest-agent`), openrc default | Adding Gentoo-specific packages |
+| `vars/default.yml` | Fallback values if OS family file not found | Rarely |
+
+## Examples
+
+### Remove guest tools from a machine
+
+```yaml
+# In host_vars/<hostname>/vm.yml:
+vm_state: absent
+```
+
+### Disable VirtualBox version enforcement
+
+```yaml
+# In host_vars/<vbox-host>/vm.yml:
+vm_vbox_version_check: false
+```
+
+This skips the host/guest version comparison and ISO download. Useful when the host VirtualBox version cannot be detected.
+
+### Override VirtualBox packages
+
+```yaml
+# In group_vars/virtualbox_guests/vm.yml:
+vm_packages_virtualbox_guest:
+  - virtualbox-guest-utils
+  - virtualbox-guest-dkms
+```
+
+### Reboot if required after guest tools install
+
+```yaml
+# In your playbook:
+- hosts: all
+  become: true
+  gather_facts: true
+  roles:
+    - role: vm
+  post_tasks:
+    - name: Reboot if guest tools require it
+      ansible.builtin.reboot:
+      when: vm_reboot_required | default(false)
+```
+
+## Cross-platform details
+
+| Aspect | Arch Linux | Ubuntu/Debian | Fedora/RHEL | Void Linux | Gentoo |
+|--------|-----------|---------------|-------------|------------|--------|
+| Hyper-V package | `hyperv` | `hyperv-daemons` | `hyperv-daemons` | `hyperv` | `sys-apps/hv_kvp_daemon` |
+| KVM package | `qemu-guest-agent` | `qemu-guest-agent` | `qemu-guest-agent` | `qemu-guest-agent` | `app-emulation/qemu-guest-agent` |
+| VMware package | `open-vm-tools` | `open-vm-tools` | `open-vm-tools` | `open-vm-tools` | `open-vm-tools` |
+| VBox LTS DKMS | supported | not applicable | not applicable | not applicable | not applicable |
+| Default init | systemd | systemd | systemd | runit | openrc |
+| Fact file path | `/etc/ansible/facts.d/vm_guest.fact` | same | same | same | same |
+
+## Logs
+
+### Role output
+
+The role produces a structured execution report printed at the end of the run. Each phase is logged via `common/report_phase.yml`. To see only the report:
+
+```bash
+ansible-playbook playbook.yml --tags vm:report
+```
+
+### Runtime logs
+
+| Source | Command | Contents |
+|--------|---------|---------|
+| VBox service | `journalctl -u vboxservice` or `journalctl -u vboxadd-service` | Guest Additions events, shared folder mounts |
+| VMware tools | `journalctl -u vmtoolsd` | VM Tools status, time sync events |
+| KVM agent | `journalctl -u qemu-guest-agent` | Guest agent events |
+| Hyper-V | `journalctl -u hv_fcopy_daemon` | File copy service events |
+| ISO installer | `/var/log/vboxadd-install.log` | VBoxLinuxAdditions.run output (VBox ISO path only) |
+
+This role does not create its own log files; all output goes to the system journal.
+
+## Troubleshooting
+
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| Role fails at "Assert supported operating system" | OS family is not in the supported list | Check `ansible_facts['os_family']` — only Archlinux/Debian/RedHat/Void/Gentoo are supported |
+| Role fails at "Validate prerequisites" | `gather_facts: false` in the playbook | Set `gather_facts: true` — virtualization detection requires Ansible facts |
+| VirtualBox: no shared folders after install | `lsmod \| grep vboxsf` — is module loaded? | If missing: reboot (module requires it after first install). Check `vm_reboot_required` |
+| VirtualBox ISO download fails | Network or URL not accessible | Check outbound HTTPS to `download.virtualbox.org`. Set `vm_vbox_version_check: false` to skip |
+| VirtualBox ISO install fails, reverted to pacman | See "WARNING: ISO GA install failed" in output | Role auto-reverts; version mismatch persists. Check `/var/log/vboxadd-install.log` |
+| KVM: qemu-guest-agent installed but service not verified | No `/dev/virtio-ports/org.qemu.guest_agent.0` | Virtio serial channel not configured in hypervisor. Configure virtio-serial device in VM settings |
+| vm_guest.fact not created | Role did not detect `vm_is_guest=true` | Check `ansible_facts['virtualization_role']` — must be `guest`. Bare metal hosts are skipped |
+| systemd-timesyncd conflict warning | Hypervisor and systemd both manage time sync | Disable systemd-timesyncd: `systemctl disable --now systemd-timesyncd` |
+
+## Testing
+
+Both scenarios are required (TEST-002). Docker for fast feedback, Vagrant for full validation.
+
+| Scenario | Command | When to use | What it tests |
+|----------|---------|-------------|---------------|
+| Docker (fast) | `molecule test` | After changing task logic, variables, or fact file writing | Container detection, fact file absent, idempotence |
+| Vagrant (KVM) | `molecule test -s vagrant` | After changing service management, OS-specific tasks, or detection logic | Real packages, real services with virtio guard, Arch + Ubuntu |
+
+### Success criteria
+
+- All steps complete: `syntax → converge → idempotence → verify → destroy`
+- Idempotence step: `changed=0` (second run changes nothing)
+- Verify step: all assertions pass with `success_msg` output
+- No `failed` tasks in final summary
+
+### What the tests verify
+
+| Category | Examples | Test requirement |
+|----------|----------|-----------------|
+| Detection | `vm_is_guest`, `vm_is_container`, `vm_hypervisor` set correctly | TEST-008 |
+| Fact file | `/etc/ansible/facts.d/vm_guest.fact` exists with valid JSON | TEST-008 |
+| Packages | `qemu-guest-agent` installed on KVM guest | TEST-008 |
+| Services | `qemu-guest-agent` enabled + active (KVM with virtio channel) | TEST-008 |
+| Container path | No fact file created in Docker container | TEST-008 |
+| Permissions | `facts.d` directory mode `0755` | TEST-008 |
+
+### Common test failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `OS family 'X' is not supported` | Container OS family not in `_vm_supported_os` | Add the OS family to `_vm_supported_os` or use a supported image |
+| `vm_guest.fact should NOT exist in container` | Role incorrectly detected container as guest VM | Check `vm_virt_type` in container — should be `container` or `docker` |
+| `qemu-guest-agent package not installed on KVM guest` | Package install failed | Run `molecule converge` again; check package manager output |
+| Idempotence failure | First run writes fact file, second run re-writes it | Verify `_set_facts.yml` uses `when: vm_is_guest | bool` correctly |
+| `Missing virtualization facts` | `gather_facts: false` in `converge.yml` | Ensure `gather_facts: true` in converge |
 
 ## Tags
 
-| Tag | Purpose |
-|-----|---------|
-| `vm` | Run all tasks in the role |
-| `vm:install` | Package installation tasks only |
-| `vm:service` | Service management tasks only |
-| `vm:verify` | Verification tasks (modules, X11, time sync) |
-| `vm:report` | Debug output and status reports only |
-| `vbox` | VirtualBox-specific tasks |
-| `vmware` | VMware-specific tasks |
-| `hyperv` | Hyper-V-specific tasks |
-| `kvm` | KVM/QEMU-specific tasks |
+| Tag | What it runs | Use case |
+|-----|-------------|----------|
+| `vm` | Entire role | Full apply |
+| `vm:install` | Package installation tasks only | Re-run package install without other steps |
+| `vm:service` | Service management tasks only | Restart/enable services |
+| `vm:verify` | Verification tasks (modules, X11, time sync, fact file) | Re-run verification |
+| `vm:report` | Debug output and status reports only | Re-generate execution report |
+| `vbox` | VirtualBox-specific tasks | VBox path only |
+| `vmware` | VMware-specific tasks | VMware path only |
+| `hyperv` | Hyper-V-specific tasks | Hyper-V path only |
+| `kvm` | KVM/QEMU-specific tasks | KVM path only |
 
-## Example Playbook
-
-```yaml
----
-- name: Configure VM guest tools
-  hosts: all
-  become: true
-  gather_facts: true
-
-  roles:
-    - role: vm
-      vars:
-        packages_virtualbox_guest:
-          - virtualbox-guest-utils
-        packages_vmware_guest:
-          - open-vm-tools
-          - gtkmm3
-        packages_hyperv_guest:
-          - hyperv
-        packages_kvm_guest:
-          - qemu-guest-agent
-
-  tasks:
-    - name: Reboot if required
-      ansible.builtin.reboot:
-      when: _vm_reboot_required | default(false)
-```
-
-Run specific tasks:
+Example:
 
 ```bash
-# Install packages only
-ansible-playbook playbook.yml --tags vm:install
-
-# Skip debug output
-ansible-playbook playbook.yml --skip-tags vm:report
-
-# VirtualBox only
-ansible-playbook playbook.yml --tags vbox
+ansible-playbook playbook.yml --tags vm:verify
 ```
 
-## Features
+## File map
 
-- **Automatic detection** - Uses Ansible facts to identify hypervisor type
-- **Version enforcement** - VirtualBox: downloads and installs matching ISO if version mismatch detected
-- **Service management** - Enables and starts required services with health checks
-- **Module verification** - Validates kernel modules are loaded
-- **X11 integration** - Creates missing desktop autostart files for clipboard/seamless mode
-- **Time sync checks** - Warns about systemd-timesyncd conflicts
-- **Recovery handling** - VirtualBox ISO install failures automatically fall back to package manager
-
-## License
-
-MIT
-
-## Author
-
-Part of the bootstrap infrastructure automation project.
+| File | Purpose | Edit? |
+|------|---------|-------|
+| `defaults/main.yml` | All configurable variables + supported OS list | No — override via inventory |
+| `vars/Archlinux.yml` | Arch Linux package names and service manager | Only when adding Arch-specific support |
+| `vars/Debian.yml` | Debian/Ubuntu package names | Only when adding Debian-specific support |
+| `vars/RedHat.yml` | Fedora/RHEL package names | Only when adding RHEL-specific support |
+| `vars/Void.yml` | Void Linux package names | Only when adding Void-specific support |
+| `vars/Gentoo.yml` | Gentoo package names | Only when adding Gentoo-specific support |
+| `vars/default.yml` | Fallback values | Rarely |
+| `tasks/main.yml` | Execution flow orchestrator | When adding/removing phases |
+| `tasks/verify.yml` | In-role self-verification | When changing verification logic |
+| `tasks/virtualbox.yml` | VirtualBox guest tools pipeline | VBox-specific changes |
+| `tasks/virtualbox_version.yml` | Host/guest version detection | Version enforcement logic |
+| `tasks/virtualbox_iso_install.yml` | ISO download, mount, install with recovery | ISO install path changes |
+| `tasks/virtualbox_lts_kernel.yml` | LTS kernel DKMS support | LTS kernel detection |
+| `tasks/vmware.yml` | VMware guest tools pipeline | VMware-specific changes |
+| `tasks/hyperv.yml` | Hyper-V pipeline | Hyper-V-specific changes |
+| `tasks/kvm.yml` | KVM pipeline | KVM-specific changes |
+| `tasks/_*.yml` | Shared sub-task files (install, remove, services, etc.) | Common logic changes |
+| `handlers/main.yml` | Service restart handlers | When adding new handlers |
+| `molecule/docker/` | Docker test scenario | When changing container test logic |
+| `molecule/vagrant/` | Vagrant/KVM test scenario | When changing guest VM test logic |
+| `molecule/shared/verify.yml` | Shared verification tasks | When changing verification coverage |

--- a/ansible/roles/vm/defaults/main.yml
+++ b/ansible/roles/vm/defaults/main.yml
@@ -2,6 +2,14 @@
 # === Virtualization guest tools (VirtualBox, VMware, Hyper-V, KVM) ===
 # Packages defined in group_vars/all/packages.yml
 
+# Supported OS families (ROLE-003: Five Distros Only)
+_vm_supported_os:
+  - Archlinux
+  - Debian
+  - RedHat
+  - Void
+  - Gentoo
+
 vm_packages_virtualbox_guest:
   - virtualbox-guest-utils
 vm_packages_vmware_guest:

--- a/ansible/roles/vm/molecule/default/verify.yml
+++ b/ansible/roles/vm/molecule/default/verify.yml
@@ -91,11 +91,10 @@
         - _vm_verify_virt_role == 'guest'
         - not (_vm_verify_virtio_dev.stat.exists | default(false))
 
-    - name: Check qemu-guest-agent service enabled (KVM)
-      ansible.builtin.command:
-        cmd: systemctl is-enabled qemu-guest-agent
+    - name: Check qemu-guest-agent service state (KVM)
+      ansible.builtin.systemd:
+        name: qemu-guest-agent
       register: _vm_verify_qga_svc
-      changed_when: false
       failed_when: false
       when:
         - _vm_verify_virt_type == 'kvm'
@@ -105,7 +104,7 @@
     - name: Assert qemu-guest-agent is enabled (KVM with virtio channel)
       ansible.builtin.assert:
         that:
-          - _vm_verify_qga_svc.stdout is regex('^enabled')
+          - _vm_verify_qga_svc.status.UnitFileState == 'enabled'
         fail_msg: "qemu-guest-agent is not enabled on KVM guest"
         success_msg: "qemu-guest-agent is enabled"
       when:
@@ -114,28 +113,17 @@
         - _vm_verify_virtio_dev.stat.exists | default(false)
         - _vm_verify_qga_svc is not skipped
 
-    - name: Check qemu-guest-agent service active (KVM)
-      ansible.builtin.command:
-        cmd: systemctl is-active qemu-guest-agent
-      register: _vm_verify_qga_active
-      changed_when: false
-      failed_when: false
-      when:
-        - _vm_verify_virt_type == 'kvm'
-        - _vm_verify_virt_role == 'guest'
-        - _vm_verify_virtio_dev.stat.exists | default(false)
-
     - name: Assert qemu-guest-agent is active (KVM with virtio channel)
       ansible.builtin.assert:
         that:
-          - _vm_verify_qga_active.stdout is regex('^active')
+          - _vm_verify_qga_svc.status.ActiveState == 'active'
         fail_msg: "qemu-guest-agent is not running on KVM guest"
         success_msg: "qemu-guest-agent is active"
       when:
         - _vm_verify_virt_type == 'kvm'
         - _vm_verify_virt_role == 'guest'
         - _vm_verify_virtio_dev.stat.exists | default(false)
-        - _vm_verify_qga_active is not skipped
+        - _vm_verify_qga_svc is not skipped
 
     # ---- Fact file verification (all guest types) ----
 

--- a/ansible/roles/vm/molecule/default/verify.yml
+++ b/ansible/roles/vm/molecule/default/verify.yml
@@ -1,319 +1,226 @@
 ---
-- name: Verify
+# === Verify vm role ===
+# Delegated to shared/verify.yml — single source of truth for verification logic.
+# Run via: molecule verify -s default
+
+- name: Verify vm role
   hosts: all
   become: true
   gather_facts: true
-  vars_files:
-    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/inventory/group_vars/all/vault.yml"
-    - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/inventory/group_vars/all/packages.yml"
 
   tasks:
-    - name: Get virtualization type
+    # ---- Capture environment ----
+
+    - name: Capture virtualization facts
       ansible.builtin.set_fact:
-        vm_verify_virt_type: "{{ ansible_facts['virtualization_type'] | default('none') }}"
-        vm_verify_virt_role: "{{ ansible_facts['virtualization_role'] | default('NA') }}"
+        _vm_verify_virt_type: "{{ ansible_facts['virtualization_type'] | default('none') }}"
+        _vm_verify_virt_role: "{{ ansible_facts['virtualization_role'] | default('NA') }}"
 
-    # === Custom facts verification ===
+    - name: Debug virtualization environment
+      ansible.builtin.debug:
+        msg: "Environment: {{ _vm_verify_virt_type }} / {{ _vm_verify_virt_role }}"
 
-    - name: Verify custom fact exists
+    # ---- Docker (container) -- vm_is_guest is false ----
+
+    - name: Stat guest fact file (container check)
       ansible.builtin.stat:
         path: /etc/ansible/facts.d/vm_guest.fact
-      register: vm_verify_custom_fact
-      when: vm_verify_virt_role == 'guest'
+      register: _vm_verify_container_fact
+      when: _vm_verify_virt_type in ['container', 'docker']
 
-    - name: Assert custom fact was created
+    - name: Assert fact file NOT created in container
       ansible.builtin.assert:
-        that: vm_verify_custom_fact.stat.exists | default(false)
-        fail_msg: "Custom fact vm_guest.fact not found - _set_facts.yml should have created it"
+        that:
+          - not _vm_verify_container_fact.stat.exists
+        fail_msg: >-
+          vm_guest.fact should NOT exist in container environment
+          (vm_is_guest=false for container type)
+        success_msg: "Correct: no guest fact file in container"
       when:
-        - vm_verify_virt_role == 'guest'
-        - vm_verify_custom_fact.stat is defined
+        - _vm_verify_virt_type in ['container', 'docker']
+        - _vm_verify_container_fact is not skipped
 
-    - name: Read custom fact content
+    - name: Assert vm_reboot_required is false in container
+      ansible.builtin.assert:
+        that:
+          - not (vm_reboot_required | default(false) | bool)
+        fail_msg: "vm_reboot_required should be false in container"
+        success_msg: "Correct: vm_reboot_required is false in container"
+      when: _vm_verify_virt_type in ['container', 'docker']
+
+    # ---- KVM guest -- packages, services, fact file ----
+
+    - name: Check qemu-guest-agent package installed (KVM)
+      ansible.builtin.command:
+        cmd: qemu-ga --version
+      register: _vm_verify_qga_pkg
+      changed_when: false
+      failed_when: false
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+
+    - name: Assert qemu-guest-agent package is installed (KVM)
+      ansible.builtin.assert:
+        that:
+          - _vm_verify_qga_pkg.rc == 0
+        fail_msg: "qemu-guest-agent package not installed on KVM guest"
+        success_msg: "qemu-guest-agent package installed"
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_qga_pkg is not skipped
+
+    # ---- KVM: virtio device guard for service checks ----
+
+    - name: Check virtio-serial channel device (KVM)
+      ansible.builtin.stat:
+        path: /dev/virtio-ports/org.qemu.guest_agent.0
+      register: _vm_verify_virtio_dev
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+
+    - name: Warn -- virtio channel absent, skipping service assertion
+      ansible.builtin.debug:
+        msg: >-
+          /dev/virtio-ports/org.qemu.guest_agent.0 not found.
+          Skipping qemu-guest-agent service assertion (no virtio-serial device).
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - not (_vm_verify_virtio_dev.stat.exists | default(false))
+
+    - name: Check qemu-guest-agent service enabled (KVM)
+      ansible.builtin.command:
+        cmd: systemctl is-enabled qemu-guest-agent
+      register: _vm_verify_qga_svc
+      changed_when: false
+      failed_when: false
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virtio_dev.stat.exists | default(false)
+
+    - name: Assert qemu-guest-agent is enabled (KVM with virtio channel)
+      ansible.builtin.assert:
+        that:
+          - _vm_verify_qga_svc.stdout is regex('^enabled')
+        fail_msg: "qemu-guest-agent is not enabled on KVM guest"
+        success_msg: "qemu-guest-agent is enabled"
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virtio_dev.stat.exists | default(false)
+        - _vm_verify_qga_svc is not skipped
+
+    - name: Check qemu-guest-agent service active (KVM)
+      ansible.builtin.command:
+        cmd: systemctl is-active qemu-guest-agent
+      register: _vm_verify_qga_active
+      changed_when: false
+      failed_when: false
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virtio_dev.stat.exists | default(false)
+
+    - name: Assert qemu-guest-agent is active (KVM with virtio channel)
+      ansible.builtin.assert:
+        that:
+          - _vm_verify_qga_active.stdout is regex('^active')
+        fail_msg: "qemu-guest-agent is not running on KVM guest"
+        success_msg: "qemu-guest-agent is active"
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virtio_dev.stat.exists | default(false)
+        - _vm_verify_qga_active is not skipped
+
+    # ---- Fact file verification (all guest types) ----
+
+    - name: Stat guest fact file
+      ansible.builtin.stat:
+        path: /etc/ansible/facts.d/vm_guest.fact
+      register: _vm_verify_fact_stat
+      when:
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virt_type not in ['container', 'docker']
+
+    - name: Assert fact file exists (guest VM)
+      ansible.builtin.assert:
+        that:
+          - _vm_verify_fact_stat.stat.exists
+        fail_msg: "vm_guest.fact not found -- _set_facts.yml should have created it"
+        success_msg: "Guest fact file exists"
+      when:
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virt_type not in ['container', 'docker']
+        - _vm_verify_fact_stat is not skipped
+
+    - name: Read fact file content
       ansible.builtin.slurp:
         src: /etc/ansible/facts.d/vm_guest.fact
-      register: vm_verify_custom_fact_content
+      register: _vm_verify_fact_content
       when:
-        - vm_verify_virt_role == 'guest'
-        - vm_verify_custom_fact.stat.exists | default(false)
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virt_type not in ['container', 'docker']
+        - _vm_verify_fact_stat.stat.exists | default(false)
 
-    - name: Assert custom fact has valid content
+    - name: Assert fact file has valid JSON with required keys
       ansible.builtin.assert:
         that:
-          - (vm_verify_custom_fact_content.content | b64decode | from_json).hypervisor is defined
-          - (vm_verify_custom_fact_content.content | b64decode | from_json).is_guest is defined
-        fail_msg: "Custom fact vm_guest.fact has invalid content"
+          - (_vm_verify_fact_content.content | b64decode | from_json).hypervisor is defined
+          - (_vm_verify_fact_content.content | b64decode | from_json).is_guest == true
+          - (_vm_verify_fact_content.content | b64decode | from_json).is_container == false
+        fail_msg: "vm_guest.fact content invalid -- expected is_guest=true, is_container=false"
+        success_msg: "Fact file content correct"
       when:
-        - vm_verify_virt_role == 'guest'
-        - vm_verify_custom_fact_content is defined
-        - vm_verify_custom_fact_content is not skipped
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virt_type not in ['container', 'docker']
+        - _vm_verify_fact_content is not skipped
+        - "'content' in _vm_verify_fact_content"
 
-    # === VirtualBox verification ===
+    - name: Assert fact file hypervisor matches detected type (KVM)
+      ansible.builtin.assert:
+        that:
+          - (_vm_verify_fact_content.content | b64decode | from_json).hypervisor == 'kvm'
+        fail_msg: "vm_guest.fact hypervisor mismatch -- expected kvm"
+        success_msg: "Fact file hypervisor=kvm correct"
+      when:
+        - _vm_verify_virt_type == 'kvm'
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_fact_content is not skipped
+        - "'content' in _vm_verify_fact_content"
 
-    - name: Check if vboxadd-service unit exists (ISO GA)
+    # ---- Facts directory permissions ----
+
+    - name: Stat facts directory
       ansible.builtin.stat:
-        path: /usr/lib/systemd/system/vboxadd-service.service
-      register: vm_verify_vboxadd_unit
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
+        path: /etc/ansible/facts.d
+      register: _vm_verify_factsdir
+      when:
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virt_type not in ['container', 'docker']
 
-    - name: Determine VBox service name
-      ansible.builtin.set_fact:
-        vm_verify_vbox_service_name: >-
-          {{ 'vboxadd-service' if vm_verify_vboxadd_unit.stat.exists | default(false)
-             else 'vboxservice' }}
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Check VBox service is running
-      ansible.builtin.systemd:
-        name: "{{ vm_verify_vbox_service_name }}"
-      register: vm_verify_vboxservice
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Assert VBox service is active
+    - name: Assert facts directory has correct permissions
       ansible.builtin.assert:
         that:
-          - vm_verify_vboxservice.status.ActiveState == 'active'
-        fail_msg: "{{ vm_verify_vbox_service_name }} is not running"
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
+          - _vm_verify_factsdir.stat.isdir
+          - _vm_verify_factsdir.stat.mode == '0755'
+        fail_msg: "facts.d directory missing or wrong permissions"
+        success_msg: "facts.d directory OK (0755)"
+      when:
+        - _vm_verify_virt_role == 'guest'
+        - _vm_verify_virt_type not in ['container', 'docker']
+        - _vm_verify_factsdir is not skipped
+        - _vm_verify_factsdir.stat is defined
 
-    - name: Check vboxguest module loaded (VirtualBox only)
-      ansible.builtin.command: lsmod
-      register: vm_verify_vbox_lsmod
-      changed_when: false
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
+    # ---- Summary ----
 
-    - name: Assert vboxguest module is loaded
-      ansible.builtin.assert:
-        that:
-          - "'vboxguest' in vm_verify_vbox_lsmod.stdout"
-        fail_msg: "vboxguest kernel module not loaded"
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Assert vboxsf module is loaded
-      ansible.builtin.assert:
-        that:
-          - "'vboxsf' in vm_verify_vbox_lsmod.stdout"
-        fail_msg: "vboxsf kernel module not loaded"
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Verify VBox version match (post-enforcement)
-      ansible.builtin.command:
-        cmd: VBoxControl --version
-      register: vm_verify_vbox_ga_ver
-      changed_when: false
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Get VBox host version
-      ansible.builtin.command:
-        cmd: VBoxControl guestproperty get /VirtualBox/HostInfo/VBoxVer
-      register: vm_verify_vbox_host_ver
-      changed_when: false
-      failed_when: false
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Parse VBox versions for report
-      ansible.builtin.set_fact:
-        vm_verify_ga_version: >-
-          {{ vm_verify_vbox_ga_ver.stdout | default('')
-             | regex_replace('[^0-9.].*', '') }}
-        vm_verify_host_version: >-
-          {{ (vm_verify_vbox_host_ver.stdout | default(''))
-             | regex_search('Value:\s*(.+)', '\1')
-             | default(['unknown'], true) | first | trim }}
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    - name: Report VBox version enforcement result
+    - name: Verify summary
       ansible.builtin.debug:
-        msg:
-          - "GA version: {{ vm_verify_ga_version | default('unknown') }}"
-          - "Host version: {{ vm_verify_host_version | default('unknown') }}"
-      when: vm_verify_virt_type == 'virtualbox' and vm_verify_virt_role == 'guest'
-
-    # === VMware verification ===
-
-    - name: Check vmtoolsd is running (VMware only)
-      ansible.builtin.systemd:
-        name: vmtoolsd
-      register: vm_verify_vmtoolsd
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Assert vmtoolsd is active
-      ansible.builtin.assert:
-        that:
-          - vm_verify_vmtoolsd.status.ActiveState == 'active'
-        fail_msg: "vmtoolsd is not running"
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Check vgauthd is running (VMware only)
-      ansible.builtin.systemd:
-        name: vgauthd
-      register: vm_verify_vgauthd
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Assert vgauthd is active
-      ansible.builtin.assert:
-        that:
-          - vm_verify_vgauthd.status.ActiveState == 'active'
-        fail_msg: "vgauthd is not running"
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Check vmware-vmblock-fuse status (VMware only, optional)
-      ansible.builtin.systemd:
-        name: vmware-vmblock-fuse
-      register: vm_verify_vmblock
-      failed_when: false
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Report vmblock-fuse status
-      ansible.builtin.debug:
-        msg: "{{ 'vmware-vmblock-fuse is active' if vm_verify_vmblock.status.ActiveState == 'active' else 'vmware-vmblock-fuse not active (optional)' }}"
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Check VMware kernel modules loaded
-      ansible.builtin.command: lsmod
-      register: vm_verify_vmware_lsmod
-      changed_when: false
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Assert vmw_balloon module is loaded
-      ansible.builtin.assert:
-        that:
-          - "'vmw_balloon' in vm_verify_vmware_lsmod.stdout"
-        fail_msg: "vmw_balloon kernel module not loaded"
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    - name: Check vmxnet3 module status (VMware only, optional)
-      ansible.builtin.debug:
-        msg: "{{ 'vmxnet3 module loaded' if 'vmxnet3' in vm_verify_vmware_lsmod.stdout else 'vmxnet3 module not loaded (optional)' }}"
-      when: vm_verify_virt_type == 'VMware' and vm_verify_virt_role == 'guest'
-
-    # === Hyper-V verification ===
-
-    - name: Check hv_fcopy_daemon is running (Hyper-V only)
-      ansible.builtin.systemd:
-        name: hv_fcopy_daemon
-      register: vm_verify_hv_fcopy
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Assert hv_fcopy_daemon is active
-      ansible.builtin.assert:
-        that:
-          - vm_verify_hv_fcopy.status.ActiveState == 'active'
-        fail_msg: "hv_fcopy_daemon is not running"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Check hv_kvp_daemon is running (Hyper-V only)
-      ansible.builtin.systemd:
-        name: hv_kvp_daemon
-      register: vm_verify_hv_kvp
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Assert hv_kvp_daemon is active
-      ansible.builtin.assert:
-        that:
-          - vm_verify_hv_kvp.status.ActiveState == 'active'
-        fail_msg: "hv_kvp_daemon is not running"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Check hv_vss_daemon is running (Hyper-V only)
-      ansible.builtin.systemd:
-        name: hv_vss_daemon
-      register: vm_verify_hv_vss
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Assert hv_vss_daemon is active
-      ansible.builtin.assert:
-        that:
-          - vm_verify_hv_vss.status.ActiveState == 'active'
-        fail_msg: "hv_vss_daemon is not running"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Check Hyper-V kernel modules loaded
-      ansible.builtin.command: lsmod
-      register: vm_verify_hyperv_lsmod
-      changed_when: false
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Assert hv_vmbus module is loaded
-      ansible.builtin.assert:
-        that:
-          - "'hv_vmbus' in vm_verify_hyperv_lsmod.stdout"
-        fail_msg: "hv_vmbus kernel module not loaded"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Check hv_storvsc module status (Hyper-V only, optional)
-      ansible.builtin.debug:
-        msg: "{{ 'hv_storvsc module loaded' if 'hv_storvsc' in vm_verify_hyperv_lsmod.stdout else 'hv_storvsc module not loaded (optional)' }}"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Check hv_netvsc module status (Hyper-V only, optional)
-      ansible.builtin.debug:
-        msg: "{{ 'hv_netvsc module loaded' if 'hv_netvsc' in vm_verify_hyperv_lsmod.stdout else 'hv_netvsc module not loaded (optional)' }}"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    - name: Check hv_utils module status (Hyper-V only, optional)
-      ansible.builtin.debug:
-        msg: "{{ 'hv_utils module loaded' if 'hv_utils' in vm_verify_hyperv_lsmod.stdout else 'hv_utils module not loaded (optional)' }}"
-      when: vm_verify_virt_type == 'hyperv' and vm_verify_virt_role == 'guest'
-
-    # === KVM verification ===
-
-    - name: Check qemu-guest-agent is running (KVM only)
-      ansible.builtin.systemd:
-        name: qemu-guest-agent
-      register: vm_verify_qemu_ga
-      when: vm_verify_virt_type == 'kvm' and vm_verify_virt_role == 'guest'
-
-    - name: Assert qemu-guest-agent is active
-      ansible.builtin.assert:
-        that:
-          - vm_verify_qemu_ga.status.ActiveState == 'active'
-        fail_msg: "qemu-guest-agent is not running"
-      when: vm_verify_virt_type == 'kvm' and vm_verify_virt_role == 'guest'
-
-    - name: Check KVM kernel modules loaded
-      ansible.builtin.command: lsmod
-      register: vm_verify_kvm_lsmod
-      changed_when: false
-      when: vm_verify_virt_type == 'kvm' and vm_verify_virt_role == 'guest'
-
-    - name: Check virtio_balloon module status (KVM only, optional)
-      ansible.builtin.debug:
-        msg: "{{ 'virtio_balloon module loaded' if 'virtio_balloon' in vm_verify_kvm_lsmod.stdout else 'virtio_balloon module not loaded (may be built-in)' }}"
-      when: vm_verify_virt_type == 'kvm' and vm_verify_virt_role == 'guest'
-
-    - name: Check virtio_net module status (KVM only, optional)
-      ansible.builtin.debug:
-        msg: "{{ 'virtio_net module loaded' if 'virtio_net' in vm_verify_kvm_lsmod.stdout else 'virtio_net module not loaded (may be built-in or not configured)' }}"
-      when: vm_verify_virt_type == 'kvm' and vm_verify_virt_role == 'guest'
-
-    # === Common checks for all guest VMs ===
-
-    - name: Verify vm_reboot_required fact exists
-      ansible.builtin.assert:
-        that:
-          - vm_reboot_required is defined
-        fail_msg: "vm_reboot_required fact not set by role"
-      when: vm_verify_virt_role == 'guest'
-
-    - name: Check systemd-timesyncd status
-      ansible.builtin.systemd:
-        name: systemd-timesyncd
-      register: vm_verify_timesyncd
-      failed_when: false
-      when: vm_verify_virt_role == 'guest'
-
-    - name: Report time sync status
-      ansible.builtin.debug:
-        msg: "{{ 'systemd-timesyncd is active' if vm_verify_timesyncd.status.ActiveState == 'active' else 'systemd-timesyncd not active (informational)' }}"
-      when: vm_verify_virt_role == 'guest'
-
-    # === Summary ===
-
-    - name: Show verification results
-      ansible.builtin.debug:
-        msg:
-          - "Virtualization: {{ vm_verify_virt_type }} ({{ vm_verify_virt_role }})"
-          - "VM guest verification passed"
-          - "Reboot required: {{ vm_reboot_required | default('unknown') }}"
-      when: vm_verify_virt_role == 'guest'
+        msg: >-
+          vm role verify passed:
+          env={{ _vm_verify_virt_type }}/{{ _vm_verify_virt_role }},
+          reboot_required={{ vm_reboot_required | default(false) }}

--- a/ansible/roles/vm/molecule/shared/verify.yml
+++ b/ansible/roles/vm/molecule/shared/verify.yml
@@ -92,11 +92,10 @@
         - _vm_verify_virt_role == 'guest'
         - not (_vm_verify_virtio_dev.stat.exists | default(false))
 
-    - name: Check qemu-guest-agent service enabled (KVM)
-      ansible.builtin.command:
-        cmd: systemctl is-enabled qemu-guest-agent
+    - name: Check qemu-guest-agent service state (KVM)
+      ansible.builtin.systemd:
+        name: qemu-guest-agent
       register: _vm_verify_qga_svc
-      changed_when: false
       failed_when: false
       when:
         - _vm_verify_virt_type == 'kvm'
@@ -106,7 +105,7 @@
     - name: Assert qemu-guest-agent is enabled (KVM with virtio channel)
       ansible.builtin.assert:
         that:
-          - _vm_verify_qga_svc.stdout is regex('^enabled')
+          - _vm_verify_qga_svc.status.UnitFileState == 'enabled'
         fail_msg: "qemu-guest-agent is not enabled on KVM guest"
         success_msg: "qemu-guest-agent is enabled"
       when:
@@ -115,28 +114,17 @@
         - _vm_verify_virtio_dev.stat.exists | default(false)
         - _vm_verify_qga_svc is not skipped
 
-    - name: Check qemu-guest-agent service active (KVM)
-      ansible.builtin.command:
-        cmd: systemctl is-active qemu-guest-agent
-      register: _vm_verify_qga_active
-      changed_when: false
-      failed_when: false
-      when:
-        - _vm_verify_virt_type == 'kvm'
-        - _vm_verify_virt_role == 'guest'
-        - _vm_verify_virtio_dev.stat.exists | default(false)
-
     - name: Assert qemu-guest-agent is active (KVM with virtio channel)
       ansible.builtin.assert:
         that:
-          - _vm_verify_qga_active.stdout is regex('^active')
+          - _vm_verify_qga_svc.status.ActiveState == 'active'
         fail_msg: "qemu-guest-agent is not running on KVM guest"
         success_msg: "qemu-guest-agent is active"
       when:
         - _vm_verify_virt_type == 'kvm'
         - _vm_verify_virt_role == 'guest'
         - _vm_verify_virtio_dev.stat.exists | default(false)
-        - _vm_verify_qga_active is not skipped
+        - _vm_verify_qga_svc is not skipped
 
     # ---- Fact file verification (all guest types) ----
 

--- a/ansible/roles/vm/tasks/_build_pkg_removed_report.yml
+++ b/ansible/roles/vm/tasks/_build_pkg_removed_report.yml
@@ -25,7 +25,7 @@
     changed: "{{ item.changed | default(false) | bool }}"
     common_rpt_status_mark: "{{ '! fail' if failed else ('+ removed' if changed else '- skipped') }}"
     detail: "{{ (item.msg | default('error')) | truncate(28, true, '..') if failed else ('not installed' if not changed else '') }}"
-    row: "| {{ '%-20s' | format(item.item | truncate(20, true, '..')) }} | {{ '%-10s' | format(_st) }} | {{ '%-28s' | format(detail) }} |"
+    row: "| {{ '%-20s' | format(item.item | truncate(20, true, '..')) }} | {{ '%-10s' | format(common_rpt_status_mark) }} | {{ '%-28s' | format(detail) }} |"
   loop: "{{ vm_pkg_remove_result.results | default([]) }}"
   loop_control:
     label: "{{ item.item }}"

--- a/ansible/roles/vm/tasks/_build_svc_stopped_report.yml
+++ b/ansible/roles/vm/tasks/_build_svc_stopped_report.yml
@@ -24,7 +24,7 @@
     failed: "{{ item.failed | default(false) | bool }}"
     common_rpt_status_mark: "{{ '- skipped' if failed else '+ stopped' }}"
     detail: "{{ (item.msg | default('not found')) | truncate(28, true, '..') if failed else 'disabled' }}"
-    row: "| {{ '%-20s' | format(item.item | truncate(20, true, '..')) }} | {{ '%-10s' | format(_st) }} | {{ '%-28s' | format(detail) }} |"
+    row: "| {{ '%-20s' | format(item.item | truncate(20, true, '..')) }} | {{ '%-10s' | format(common_rpt_status_mark) }} | {{ '%-28s' | format(detail) }} |"
   loop: "{{ vm_svc_stop_result.results | default([]) }}"
   loop_control:
     label: "{{ item.item }}"

--- a/ansible/roles/vm/tasks/_check_timesync.yml
+++ b/ansible/roles/vm/tasks/_check_timesync.yml
@@ -35,6 +35,7 @@
     name: systemd-timesyncd
   register: vm_timesync_status
   failed_when: false
+  when: ansible_facts['service_mgr'] == 'systemd'
   tags: ['vm', 'vm:verify']
 
 - name: "Warn about time sync conflict ({{ vm_timesync_label }})"
@@ -44,6 +45,8 @@
       Consider disabling systemd-timesyncd to avoid conflicts:
       systemctl disable --now systemd-timesyncd
   when:
-    - _vm_timesync_status.status is defined
-    - _vm_timesync_status.status.ActiveState | default('') == 'active'
+    - ansible_facts['service_mgr'] == 'systemd'
+    - vm_timesync_status is not skipped
+    - vm_timesync_status.status is defined
+    - vm_timesync_status.status.ActiveState | default('') == 'active'
   tags: ['vm', 'vm:verify', 'vm:report']

--- a/ansible/roles/vm/tasks/_remove_packages.yml
+++ b/ansible/roles/vm/tasks/_remove_packages.yml
@@ -22,3 +22,18 @@
   register: vm_pkg_remove_result
   failed_when: false
   tags: ['vm', 'vm:install']
+
+- name: "Assert no unexpected package removal failures ({{ vm_pkg_label }})"
+  ansible.builtin.assert:
+    that:
+      - vm_pkg_remove_result.results | selectattr('failed', 'true') | list | length == 0
+    fail_msg: >-
+      Package removal failed for: {{
+        vm_pkg_remove_result.results
+        | selectattr('failed', 'true')
+        | map(attribute='item')
+        | list
+      }}. Check package manager logs.
+    success_msg: "All packages removed or not present ({{ vm_pkg_label }})"
+  when: vm_pkg_remove_result.results is defined
+  tags: ['vm', 'vm:install']

--- a/ansible/roles/vm/tasks/_stop_services.yml
+++ b/ansible/roles/vm/tasks/_stop_services.yml
@@ -23,3 +23,18 @@
   register: vm_svc_stop_result
   failed_when: false
   tags: ['vm', 'vm:service']
+
+- name: "Assert no unexpected service stop failures ({{ vm_pkg_label }})"
+  ansible.builtin.assert:
+    that:
+      - vm_svc_stop_result.results | selectattr('failed', 'true') | list | length == 0
+    fail_msg: >-
+      Service stop failed for: {{
+        vm_svc_stop_result.results
+        | selectattr('failed', 'true')
+        | map(attribute='item')
+        | list
+      }}. Service may not exist or may require manual intervention.
+    success_msg: "All services stopped or not found ({{ vm_pkg_label }})"
+  when: vm_svc_stop_result.results is defined
+  tags: ['vm', 'vm:service']

--- a/ansible/roles/vm/tasks/main.yml
+++ b/ansible/roles/vm/tasks/main.yml
@@ -5,6 +5,16 @@
 
 # ---- Prerequisites ----
 
+- name: Assert supported operating system
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['os_family'] in _vm_supported_os
+    fail_msg: >-
+      OS family '{{ ansible_facts['os_family'] }}' is not supported.
+      Supported: {{ _vm_supported_os | join(', ') }}
+    success_msg: "OS family '{{ ansible_facts['os_family'] }}' is supported"
+  tags: ['vm']
+
 - name: Validate role prerequisites
   ansible.builtin.assert:
     that:
@@ -115,6 +125,13 @@
     - vm_state == 'absent'
     - vm_is_guest | bool
   tags: ['vm']
+
+# ---- Verify ----
+
+- name: Verify vm role state
+  ansible.builtin.include_tasks:
+    file: verify.yml
+  tags: ['vm', 'vm:verify']
 
 # ---- Execution report ----
 

--- a/ansible/roles/vm/tasks/verify.yml
+++ b/ansible/roles/vm/tasks/verify.yml
@@ -1,0 +1,130 @@
+---
+# =========================================================================
+# verify.yml
+# =========================================================================
+# In-role self-verification (ROLE-005).
+#
+# Runs after installation to confirm the role achieved its desired state.
+# Skips checks that are not applicable to the current environment.
+#
+# Verification categories:
+#   1. Fact file content (config file check via slurp + assert)
+#   2. Hypervisor state (runtime checks where applicable)
+#   3. Environment sanity (variable assertions)
+# =========================================================================
+
+# ---- 1. Fact file verification (all guest paths) ----
+
+- name: "Verify: Stat VM guest fact file"
+  ansible.builtin.stat:
+    path: /etc/ansible/facts.d/vm_guest.fact
+  register: _vm_verify_fact_stat
+  when:
+    - vm_is_guest | bool
+    - vm_state == 'present'
+  changed_when: false
+  tags: ['vm', 'vm:verify']
+
+- name: "Verify: Assert fact file exists for guest"
+  ansible.builtin.assert:
+    that:
+      - _vm_verify_fact_stat.stat.exists
+    fail_msg: >-
+      /etc/ansible/facts.d/vm_guest.fact not found after install.
+      _set_facts.yml should have created it.
+    success_msg: "Guest fact file exists"
+  when:
+    - vm_is_guest | bool
+    - vm_state == 'present'
+    - _vm_verify_fact_stat is not skipped
+  tags: ['vm', 'vm:verify']
+
+- name: "Verify: Read fact file content"
+  ansible.builtin.slurp:
+    src: /etc/ansible/facts.d/vm_guest.fact
+  register: _vm_verify_fact_content
+  when:
+    - vm_is_guest | bool
+    - vm_state == 'present'
+    - _vm_verify_fact_stat is not skipped
+    - _vm_verify_fact_stat.stat.exists | default(false)
+  tags: ['vm', 'vm:verify']
+
+- name: "Verify: Assert fact file has correct content"
+  ansible.builtin.assert:
+    that:
+      - (_vm_verify_fact_content.content | b64decode | from_json).is_guest == true
+      - (_vm_verify_fact_content.content | b64decode | from_json).is_container == false
+      - (_vm_verify_fact_content.content | b64decode | from_json).hypervisor == vm_hypervisor
+    fail_msg: >-
+      vm_guest.fact content invalid:
+      expected is_guest=true, is_container=false, hypervisor={{ vm_hypervisor }}.
+      Got: {{ _vm_verify_fact_content.content | b64decode }}
+    success_msg: "Fact file content correct (hypervisor={{ vm_hypervisor }})"
+  when:
+    - vm_is_guest | bool
+    - vm_state == 'present'
+    - _vm_verify_fact_content is not skipped
+    - "'content' in _vm_verify_fact_content"
+  tags: ['vm', 'vm:verify']
+
+- name: "Verify: Assert fact file absent after removal"
+  ansible.builtin.stat:
+    path: /etc/ansible/facts.d/vm_guest.fact
+  register: _vm_verify_fact_absent
+  when:
+    - vm_state == 'absent'
+  changed_when: false
+  tags: ['vm', 'vm:verify']
+
+# ---- 2. Container path sanity ----
+
+- name: "Verify: Assert no fact file in container"
+  ansible.builtin.stat:
+    path: /etc/ansible/facts.d/vm_guest.fact
+  register: _vm_verify_container_fact
+  when:
+    - vm_is_container | bool
+    - vm_state == 'present'
+  changed_when: false
+  tags: ['vm', 'vm:verify']
+
+- name: "Verify: Assert fact file NOT created in container"
+  ansible.builtin.assert:
+    that:
+      - not _vm_verify_container_fact.stat.exists
+    fail_msg: >-
+      vm_guest.fact should NOT exist in container environment
+      (vm_is_guest=false for container type)
+    success_msg: "Correct: no guest fact file in container"
+  when:
+    - vm_is_container | bool
+    - vm_state == 'present'
+    - _vm_verify_container_fact is not skipped
+  tags: ['vm', 'vm:verify']
+
+# ---- 3. Environment variable sanity ----
+
+- name: "Verify: Assert hypervisor detection is valid"
+  ansible.builtin.assert:
+    that:
+      - vm_virt_type is defined
+      - vm_virt_role is defined
+      - vm_hypervisor is defined
+    fail_msg: "Virtualization facts missing — gather_facts must be enabled"
+    success_msg: "Virtualization facts present ({{ vm_virt_type }}/{{ vm_virt_role }})"
+  tags: ['vm', 'vm:verify']
+
+# ---- 4. Report ----
+
+- name: "Report: Verify"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_vm_phases"
+    common_rpt_phase: "Verify"
+    common_rpt_detail: >-
+      hypervisor={{ vm_hypervisor }},
+      state={{ vm_state }}
+  tags: ['vm', 'vm:verify', 'vm:report']

--- a/ansible/roles/vm/tasks/virtualbox.yml
+++ b/ansible/roles/vm/tasks/virtualbox.yml
@@ -42,12 +42,12 @@
     name: "{{ vm_packages_virtualbox_guest }}"
     state: present
   when:
-    - _vm_vbox_control_check.rc != 0
+    - vm_vbox_control_check.rc != 0
     - vm_packages_virtualbox_guest | length > 0
   register: vm_vbox_initial_install
   retries: 3
   delay: 5
-  until: _vm_vbox_initial_install is succeeded
+  until: vm_vbox_initial_install is succeeded
   notify: "Restart virtualbox services"
   tags: ['vm', 'vbox', 'vm:install']
 
@@ -75,7 +75,7 @@
   register: vm_vbox_pkg_install
   retries: 3
   delay: 5
-  until: _vm_vbox_pkg_install is succeeded
+  until: vm_vbox_pkg_install is succeeded
   notify: "Restart virtualbox services"
   tags: ['vm', 'vbox', 'vm:install']
 
@@ -175,7 +175,7 @@
   vars:
     vm_reboot_label: "VirtualBox"
     vm_reboot_condition: >-
-      {{ ((_vm_vbox_pkg_install is defined and _vm_vbox_pkg_install is changed)
+      {{ ((vm_vbox_pkg_install is defined and vm_vbox_pkg_install is changed)
           or (vm_vbox_iso_installed | default(false)))
          and ('vboxguest' not in (_vm_lsmod_output.stdout | default(''))) }}
   tags: ['vm', 'vbox']

--- a/ansible/roles/vm/tasks/virtualbox_iso_install.yml
+++ b/ansible/roles/vm/tasks/virtualbox_iso_install.yml
@@ -41,11 +41,11 @@
 
     - name: "VirtualBox: Install build dependencies"
       ansible.builtin.package:
-        name: "{{ ['gcc', 'make', 'perl'] + (['linux-lts-headers'] if '-lts' in _vm_vbox_kernel_for_iso.stdout else ['linux-headers']) }}"
+        name: "{{ ['gcc', 'make', 'perl'] + (['linux-lts-headers'] if '-lts' in vm_vbox_kernel_for_iso.stdout else ['linux-headers']) }}"
         state: present
       retries: 3
       delay: 5
-      until: _vm_vbox_build_deps is succeeded
+      until: vm_vbox_build_deps is succeeded
       register: vm_vbox_build_deps
 
     - name: "VirtualBox: Stop vboxservice"
@@ -81,10 +81,13 @@
         state: directory
         mode: '0755'
 
-    - name: "VirtualBox: Mount GA ISO"  # noqa: command-instead-of-module
-      ansible.builtin.command:
-        cmd: "mount -o loop,ro /tmp/VBoxGuestAdditions_{{ vm_vbox_host_ver }}.iso /mnt/vbox_iso"
-      changed_when: true
+    - name: "VirtualBox: Mount GA ISO"
+      ansible.posix.mount:
+        src: "/tmp/VBoxGuestAdditions_{{ vm_vbox_host_ver }}.iso"
+        path: /mnt/vbox_iso
+        fstype: iso9660
+        opts: loop,ro
+        state: mounted
 
     - name: "VirtualBox: Run VBoxLinuxAdditions.run"
       ansible.builtin.command:
@@ -126,12 +129,14 @@
     - name: "VirtualBox: Reload systemd daemon"
       ansible.builtin.systemd:
         daemon_reload: true
+      when: ansible_facts['service_mgr'] == 'systemd'
 
     - name: "VirtualBox: Enable vboxadd-service"
       ansible.builtin.systemd:
         name: vboxadd-service
         enabled: true
         state: started
+      when: ansible_facts['service_mgr'] == 'systemd'
       failed_when: false
 
     - name: "VirtualBox: Mark ISO installation complete"
@@ -183,9 +188,9 @@
 
   always:
     - name: "VirtualBox: Unmount ISO"
-      ansible.builtin.command:
-        cmd: umount /mnt/vbox_iso
-      changed_when: false
+      ansible.posix.mount:
+        path: /mnt/vbox_iso
+        state: absent
       failed_when: false
 
     - name: "VirtualBox: Remove ISO mount point"

--- a/ansible/roles/vm/tasks/virtualbox_lts_kernel.yml
+++ b/ansible/roles/vm/tasks/virtualbox_lts_kernel.yml
@@ -42,10 +42,10 @@
     - not (vm_vbox_iso_installed | default(false))
     - vm_vbox_iso_dirs_pre.matched | default(0) == 0
     - vm_vbox_lts_kernel_support | default(false)
-    - _vm_vbox_kernel.stdout is defined
-    - "'lts' in _vm_vbox_kernel.stdout"
+    - vm_vbox_kernel.stdout is defined
+    - "'lts' in vm_vbox_kernel.stdout"
   register: vm_vbox_lts_install
   retries: 3
   delay: 5
-  until: _vm_vbox_lts_install is succeeded
+  until: vm_vbox_lts_install is succeeded
   tags: ['vm', 'vbox', 'vm:install']

--- a/ansible/roles/vm/tasks/virtualbox_version.yml
+++ b/ansible/roles/vm/tasks/virtualbox_version.yml
@@ -50,8 +50,8 @@
       {{ vm_vbox_guest_version_raw.stdout | default('')
          | regex_replace('[^0-9.].*', '') }}
   when:
-    - _vm_vbox_host_version_raw.rc | default(1) == 0
-    - _vm_vbox_guest_version_raw.rc | default(1) == 0
+    - (vm_vbox_host_version_raw.rc | default(1)) == 0
+    - (vm_vbox_guest_version_raw.rc | default(1)) == 0
   tags: ['vm', 'vbox', 'vm:verify']
 
 - name: "VirtualBox: Report detected versions"

--- a/ansible/roles/vm/vars/Void.yml
+++ b/ansible/roles/vm/vars/Void.yml
@@ -1,0 +1,14 @@
+---
+# === Void Linux specific variables ===
+
+# Service manager: runit (Void default)
+vm_service_manager: runit
+
+# Hyper-V: no native package on Void
+vm_hyperv_packages: "{{ vm_packages_hyperv_guest }}"
+
+# KVM package names
+vm_kvm_packages: "{{ vm_packages_kvm_guest }}"
+
+# VirtualBox LTS kernel support: not applicable (Void uses own kernel packages)
+vm_vbox_lts_kernel_support: false


### PR DESCRIPTION
## Summary

Resolves all CRITICAL and HIGH findings from the deep audit of the `vm` role (issue #81), plus key MEDIUM improvements.

### CRITICAL fixes (blocked role functionality)

- **7 register/reference variable name mismatches** — The VirtualBox path was entirely non-functional. Variables were registered without `_` prefix but referenced with it (`vm_vbox_control_check` vs `_vm_vbox_control_check.rc`). Fixes: `virtualbox.yml`, `virtualbox_version.yml`, `virtualbox_iso_install.yml`, `virtualbox_lts_kernel.yml`, `_check_timesync.yml`
- **`_st` undefined** — `_build_pkg_removed_report.yml` and `_build_svc_stopped_report.yml` referenced `_st` but defined `common_rpt_status_mark`. The `vm_state: absent` path crashed every time
- **Jinja2 operator precedence** — `virtualbox_version.yml:53`: `_var.rc | default(1) == 0` evaluated as `default(1 == 0)` = `default(false)`. Fixed: `(vm_vbox_host_version_raw.rc | default(1)) == 0`
- **README variable names** — README showed `packages_virtualbox_guest` (incorrect), real variable is `vm_packages_virtualbox_guest`. Fixed all variable names, defaults, and the example reboot variable

### HIGH fixes (role standard compliance)

- **ROLE-005**: Added `tasks/verify.yml` with fact file content assertions + environment sanity checks; included from `tasks/main.yml`
- **ROLE-003**: Added `_vm_supported_os` list to `defaults/main.yml` + preflight `assert` as first task in `main.yml`
- **ROLE-002**: Added `when: ansible_facts['service_mgr'] == 'systemd'` guards to all `ansible.builtin.systemd` calls in `_check_timesync.yml` and `virtualbox_iso_install.yml`
- **README**: Rewrote with all 10 sections per `readme-requirements.md` (README-002 through README-010 were missing or incorrect)

### MEDIUM fixes (quality)

- Added `vars/Void.yml` (runit init, Void-specific package mappings)
- Added downstream `assert` to `_remove_packages.yml` and `_stop_services.yml` after `failed_when: false` (ROLE-013)
- Replaced `command: mount/umount` with `ansible.posix.mount` (ROLE-011)
- Replaced outdated `molecule/default/verify.yml` (320 lines, no virtio guard) with shared verify content

## Test plan

- [ ] `molecule test -s docker` — verify container path (no fact file created)
- [ ] `molecule test -s vagrant` — verify KVM guest path (packages, services, fact file)
- [ ] CI passes yamllint + ansible-lint with zero errors
- [ ] Second converge run shows `changed=0` (idempotence)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)