### PR TITLE
fix(vm): remove antipatterns introduced in #114

### DIFF
--- a/ansible/roles/vm/tasks/_stop_services.yml
+++ b/ansible/roles/vm/tasks/_stop_services.yml
@@ -24,17 +24,16 @@
   failed_when: false
   tags: ['vm', 'vm:service']
 
-- name: "Assert no unexpected service stop failures ({{ vm_pkg_label }})"
-  ansible.builtin.assert:
-    that:
-      - vm_svc_stop_result.results | selectattr('failed', 'true') | list | length == 0
-    fail_msg: >-
-      Service stop failed for: {{
+- name: "Report service stop outcomes ({{ vm_pkg_label }})"
+  ansible.builtin.debug:
+    msg: >-
+      Services not found (expected during removal): {{
         vm_svc_stop_result.results
         | selectattr('failed', 'true')
         | map(attribute='item')
         | list
-      }}. Service may not exist or may require manual intervention.
-    success_msg: "All services stopped or not found ({{ vm_pkg_label }})"
-  when: vm_svc_stop_result.results is defined
-  tags: ['vm', 'vm:service']
+      }}
+  when:
+    - vm_svc_stop_result.results is defined
+    - vm_svc_stop_result.results | selectattr('failed', 'true') | list | length > 0
+  tags: ['vm', 'vm:service', 'vm:report']

--- a/ansible/roles/vm/tasks/virtualbox_iso_install.yml
+++ b/ansible/roles/vm/tasks/virtualbox_iso_install.yml
@@ -81,13 +81,10 @@
         state: directory
         mode: '0755'
 
-    - name: "VirtualBox: Mount GA ISO"
-      ansible.posix.mount:
-        src: "/tmp/VBoxGuestAdditions_{{ vm_vbox_host_ver }}.iso"
-        path: /mnt/vbox_iso
-        fstype: iso9660
-        opts: loop,ro
-        state: mounted
+    - name: "VirtualBox: Mount GA ISO"  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: "mount -o loop,ro /tmp/VBoxGuestAdditions_{{ vm_vbox_host_ver }}.iso /mnt/vbox_iso"
+      changed_when: true
 
     - name: "VirtualBox: Run VBoxLinuxAdditions.run"
       ansible.builtin.command:
@@ -187,10 +184,10 @@
       tags: ['vm', 'vbox', 'vm:install', 'vm:report']
 
   always:
-    - name: "VirtualBox: Unmount ISO"
-      ansible.posix.mount:
-        path: /mnt/vbox_iso
-        state: absent
+    - name: "VirtualBox: Unmount ISO"  # noqa: command-instead-of-module
+      ansible.builtin.command:
+        cmd: umount /mnt/vbox_iso
+      changed_when: false
       failed_when: false
 
     - name: "VirtualBox: Remove ISO mount point"


### PR DESCRIPTION
## Summary

Two antipatterns introduced in #114, caught during self-review.

### `_stop_services.yml` — assert → debug

`ansible.builtin.service: state: stopped` returns `failed=true` when the service does not exist. During removal (`vm_state: absent`), this is **expected** — the service may not be running. `_build_svc_stopped_report.yml` explicitly maps `failed=true` → `"- skipped"`.

The assert would fail in exactly the scenario it should not. Replaced with `debug` that lists which services were not found — visibility without false failures, matching ROLE-013 intent.

### `virtualbox_iso_install.yml` — ansible.posix.mount → command

`ansible.posix.mount: state: mounted` writes to `/etc/fstab`. A temporary loop-mounted ISO must **not** be in fstab. The original `command: mount -o loop,ro ...` with `# noqa: command-instead-of-module` was intentional — restoring it. Same for `umount` in the `always:` block.

## Test plan

- [ ] CI passes (lint + docker + vagrant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)