### PR TITLE
fix(vm): correct failed_when antipattern in _manage_services.yml

### DIFF
--- a/ansible/roles/vm/tasks/_manage_services.yml
+++ b/ansible/roles/vm/tasks/_manage_services.yml
@@ -48,9 +48,18 @@
   loop_control:
     label: "{{ item.name }} ({{ 'required' if item.required else 'optional' }})"
   register: _vm_svc_result
-  failed_when:
-    - _vm_svc_result is failed
-    - item.required
+  failed_when: false
+  tags: ['vm', 'vm:service']
+
+- name: "Fail if required service failed to start ({{ vm_svc_label }})"
+  ansible.builtin.fail:
+    msg: "Required service '{{ item.item.name }}' failed to start"
+  loop: "{{ _vm_svc_result.results }}"
+  loop_control:
+    label: "{{ item.item.name }}"
+  when:
+    - item.failed
+    - item.item.required
   tags: ['vm', 'vm:service']
 
 - name: "Check journald for service errors ({{ vm_svc_label }})"


### PR DESCRIPTION
## Summary

- `failed_when: _vm_svc_result is failed` in a loop task checked the **previous iteration's accumulated result**, not the current one
- On the first iteration `_vm_svc_result` is undefined → condition is always `False` → required services that fail never abort the play
- Fix: `failed_when: false` on the loop task + a separate `ansible.builtin.fail` task that iterates `_vm_svc_result.results` after all services have been attempted

## Root cause

In Ansible, `failed_when` is evaluated before the registered variable is updated. In a loop, `_vm_svc_result` at `failed_when`-evaluation time contains results from **prior** iterations only.

## Test plan

- [ ] VMware playbook run: optional service absent → no failure, required service absent → playbook aborts
- [ ] KVM playbook run: same validation
- [ ] CI ansible-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)