### PR TITLE
fix(sysctl): resolve audit findings from #84

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -125,6 +125,7 @@ jobs:
     if: needs.detect.outputs.empty == 'false'
     name: "${{ matrix.role }} (test-docker)"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         role: ${{ fromJSON(needs.detect.outputs.matrix) }}

--- a/ansible/roles/sysctl/README.md
+++ b/ansible/roles/sysctl/README.md
@@ -1,8 +1,154 @@
-# Ansible Role: sysctl
+# sysctl
 
-Configures Linux kernel parameters via `/etc/sysctl.d/99-z-ansible.conf` for three goals: kernel exploit hardening, network attack surface reduction, and workstation performance tuning.
+Configures Linux kernel parameters for exploit hardening, network attack surface reduction, and workstation performance tuning.
 
-Parameters are applied distribution-agnostically: `sysctl -e --system` loads all drop-in files and silently ignores parameters unsupported by the current kernel (e.g. `kernel.unprivileged_userns_clone` exists only in Arch `linux-hardened`).
+## Execution flow
+
+1. **Assert OS support** -- fails immediately if `ansible_facts['os_family']` is not in the supported list (Archlinux, Debian, RedHat, Void, Gentoo)
+2. **Install packages** (`tasks/packages.yml`) -- installs `procps-ng` (Arch/Void/Gentoo) or `procps` (Debian/RedHat) via `ansible.builtin.package`
+3. **Manage services** (`tasks/services.yml`) -- disables `apport.service` on Debian/Ubuntu if `sysctl_fs_suid_dumpable != 2` (apport overwrites this value after boot). Logs outcome if service not found.
+4. **Deploy configuration** (`tasks/deploy.yml`) -- creates `/etc/sysctl.d/` directory, deploys `/etc/sysctl.d/99-z-ansible.conf` from template. **Triggers handler:** if config changed, `sysctl -e -p` reloads parameters before verification.
+5. **Verify parameters** (`tasks/verify.yml`) -- reads 14 key security parameters via `sysctl -n`, reports OK / MISMATCH / NOT SUPPORTED / ERROR for each
+6. **Report** (`tasks/report.yml`) -- writes structured execution report via `common/report_phase` + `report_render`
+
+### Handlers
+
+| Handler | Triggered by | What it does |
+|---------|-------------|-------------|
+| `reload sysctl` | Config file change (step 4) | Runs `sysctl -e -p /etc/sysctl.d/99-z-ansible.conf`. Skipped in Docker (kernel params read-only). |
+
+## Variables
+
+### Configurable (`defaults/main.yml`)
+
+Override these via inventory (`group_vars/` or `host_vars/`), never edit `defaults/main.yml` directly.
+
+#### Feature toggles
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `sysctl_security_enabled` | `true` | safe | Master switch for all security parameters |
+| `sysctl_security_kernel_hardening` | `true` | safe | Kernel: ASLR, kptr_restrict, eBPF, ptrace, mmap_min_addr |
+| `sysctl_security_network_hardening` | `true` | safe | Network: ARP, ICMP, TCP, rp_filter, IPv6 |
+| `sysctl_security_filesystem_hardening` | `true` | safe | FS: hardlink/symlink/FIFO/SUID protection |
+| `sysctl_security_ipv6_disable` | `false` | careful | Fully disable IPv6. Breaks DNS fallback, Docker networking, Happy Eyeballs |
+
+#### Performance
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `sysctl_vm_swappiness` | `10` | safe | Swap aggressiveness. Security: `1`, Performance: `10-60` |
+| `sysctl_vm_vfs_cache_pressure` | `50` | safe | Cache eviction pressure |
+| `sysctl_vm_dirty_ratio` | `10` | safe | Dirty page flush threshold (%). For media servers: `20-40` |
+| `sysctl_vm_dirty_background_ratio` | `5` | safe | Background flush start (%) |
+| `sysctl_fs_inotify_max_user_watches` | `524288` | safe | inotify watch limit (for IDEs, file watchers) |
+| `sysctl_fs_inotify_max_user_instances` | `1024` | safe | Max inotify instances per user |
+| `sysctl_fs_file_max` | `2097152` | safe | System open file descriptor limit |
+| `sysctl_net_core_somaxconn` | `4096` | safe | TCP connection backlog (for dev servers and Docker) |
+| `sysctl_net_ipv4_tcp_fastopen` | `3` | safe | TCP Fast Open (0=off, 1=client, 2=server, 3=both) |
+| `sysctl_net_ipv4_tcp_tw_reuse` | `0` | careful | TIME_WAIT socket reuse. **Must be 0 when `tcp_timestamps=0`** |
+
+#### Security: Kernel
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `sysctl_kernel_randomize_va_space` | `2` | internal | ASLR level (2=full). Do not lower below 2 |
+| `sysctl_kernel_kptr_restrict` | `2` | internal | Kernel pointer restriction (2=always hidden) |
+| `sysctl_kernel_dmesg_restrict` | `1` | internal | Block unprivileged dmesg |
+| `sysctl_kernel_yama_ptrace_scope` | `1` (profile-aware) | careful | ptrace scope. 0=gaming (Wine/Proton), 1=dev (gdb ./app), 2=security (root only). Auto-set by `workstation_profiles` |
+| `sysctl_kernel_perf_event_paranoid` | `3` | internal | perf event access (3=kernel-only). Spectre mitigation |
+| `sysctl_kernel_unprivileged_bpf_disabled` | `1` | internal | Block unprivileged bpf(). CVE-2021-3490, CVE-2022-23222 |
+| `sysctl_kernel_tty_ldisc_autoload` | `0` | internal | Block TTY line discipline autoload. CVE-2017-2636 |
+| `sysctl_vm_unprivileged_userfaultfd` | `0` | internal | Restrict userfaultfd() to CAP_SYS_PTRACE |
+| `sysctl_vm_mmap_min_addr` | `65536` | internal | Minimum mmap address. Blocks null deref exploitation |
+| `sysctl_kernel_unprivileged_userns_clone` | `1` | careful | Arch linux-hardened kernel only. Ignored on other kernels |
+
+#### Security: Network
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `sysctl_net_core_bpf_jit_harden` | `2` | internal | BPF JIT hardening (2=all users) |
+| `sysctl_net_ipv4_rp_filter` | `1` | careful | Reverse path filter. Applied to `conf.all` + `conf.default` (not wildcard). Docker hosts may need `rp_filter=2` on bridge interfaces |
+| `sysctl_net_ipv4_tcp_syncookies` | `1` | internal | SYN cookies. Do not disable |
+| `sysctl_net_ipv4_tcp_rfc1337` | `1` | internal | TIME_WAIT assassination protection |
+| `sysctl_net_ipv4_accept_redirects` | `0` | internal | Block ICMP redirects |
+| `sysctl_net_ipv4_send_redirects` | `0` | internal | Do not send ICMP redirects |
+| `sysctl_net_ipv4_accept_source_route` | `0` | internal | Block IPv4 source routing |
+| `sysctl_net_ipv4_log_martians` | `1` | safe | Log martian packets |
+| `sysctl_net_ipv4_icmp_echo_ignore_broadcasts` | `1` | internal | Ignore broadcast ICMP echo (Smurf mitigation) |
+| `sysctl_net_ipv4_icmp_ignore_bogus_error_responses` | `1` | internal | Ignore bogus ICMP errors |
+| `sysctl_net_ipv4_tcp_timestamps` | `0` | careful | Disable TCP timestamps (uptime fingerprinting). Requires `tcp_tw_reuse=0` |
+| `sysctl_net_ipv4_arp_filter` | `1` | careful | ARP interface filter |
+| `sysctl_net_ipv4_arp_ignore` | `1` | careful | ARP reply scope. 1=safe for Docker/VM. 2=strict, breaks Docker bridge |
+| `sysctl_net_ipv4_drop_gratuitous_arp` | `0` | careful | Drop gratuitous ARP. 1 breaks keepalived/VRRP HA |
+| `sysctl_net_ipv6_accept_redirects` | `0` | internal | Block ICMPv6 redirects |
+| `sysctl_net_ipv6_accept_source_route` | `0` | internal | Block IPv6 source routing |
+| `sysctl_net_ipv6_accept_ra` | `1` | careful | Router Advertisements. 0 breaks SLAAC IPv6. Use 0 only with DHCPv6 stateful/static IPv6 |
+
+#### Security: Filesystem
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `sysctl_fs_protected_hardlinks` | `1` | internal | Hardlink protection |
+| `sysctl_fs_protected_symlinks` | `1` | internal | Symlink protection in sticky dirs |
+| `sysctl_fs_protected_fifos` | `2` | internal | FIFO write protection in sticky dirs |
+| `sysctl_fs_protected_regular` | `2` | internal | Regular file write protection in sticky dirs |
+| `sysctl_fs_suid_dumpable` | `0` | internal | Prohibit SUID core dumps. CIS 1.6.4, DISA STIG V-230462 |
+
+#### Custom parameters
+
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `sysctl_custom_params` | `[]` | safe | Additional parameters: `[{name: "kernel.param", value: "1"}]` |
+
+### Internal mappings (`vars/`)
+
+These files contain cross-platform mappings. Do not override via inventory -- edit the files directly only when adding new platform support.
+
+| File | What it contains | When to edit |
+|------|-----------------|-------------|
+| `vars/main.yml` | `_sysctl_supported_os` bridge, `_sysctl_procps_package` per-OS package name | Adding support for a new distro |
+
+## Examples
+
+### Default hardened workstation
+
+```yaml
+# In your playbook:
+- name: Harden kernel parameters
+  hosts: all
+  become: true
+  gather_facts: true
+  roles:
+    - role: sysctl
+```
+
+### Developer workstation (via inventory)
+
+```yaml
+# In group_vars/all/sysctl.yml or host_vars/<hostname>/sysctl.yml:
+sysctl_kernel_yama_ptrace_scope: 1       # allow gdb ./app (default for developer profile)
+sysctl_net_ipv4_arp_ignore: 1            # less strict ARP in VM environments
+sysctl_security_ipv6_disable: false      # keep IPv6 (default)
+```
+
+### Maximum security (server)
+
+```yaml
+# In group_vars/servers/sysctl.yml:
+sysctl_vm_swappiness: 1                  # minimize sensitive data in swap
+sysctl_kernel_yama_ptrace_scope: 2       # root-only ptrace
+sysctl_security_ipv6_disable: true       # if no IPv6 connectivity
+```
+
+### Docker host with custom bridge settings
+
+```yaml
+# In host_vars/docker-host/sysctl.yml:
+sysctl_custom_params:
+  - { name: "net.ipv4.conf.docker0.rp_filter", value: "2" }
+  - { name: "net.bridge.bridge-nf-call-iptables", value: "1" }
+```
 
 ## What this role actually does
 
@@ -10,192 +156,155 @@ Parameters are applied distribution-agnostically: `sysctl -e --system` loads all
 
 | Parameter | Effect |
 |---|---|
-| `kernel.randomize_va_space = 2` | Full ASLR — stack, heap, mmap, VDSO randomized. Attacker cannot predict addresses for ROP chains. KSPP, DISA STIG |
-| `kernel.kptr_restrict = 2` | Hide kernel addresses from `/proc/kallsyms`, `/proc/modules`. Prevents leaking pointers for exploit development |
-| `kernel.dmesg_restrict = 1` | Block unprivileged dmesg access. Kernel logs often contain pointers and sensitive boot-time data |
-| `kernel.yama.ptrace_scope = 1` | ptrace restricted to child processes. `gdb ./app` works; `strace -p <pid>` on an unrelated process does not |
-| `kernel.perf_event_paranoid = 3` | Block perf counters for unprivileged users. Mitigates Spectre side-channel via performance counters (DISA STIG V-258076) |
-| `kernel.unprivileged_bpf_disabled = 1` | Block `bpf()` without `CAP_BPF`. Closes LPE class via eBPF programs (CVE-2021-3490, CVE-2022-23222) |
-| `dev.tty.ldisc_autoload = 0` | Block TTY line discipline autoload. Closes CVE-2017-2636 (privilege escalation via TIOCSETD ioctl) |
-| `vm.unprivileged_userfaultfd = 0` | Restrict `userfaultfd()` to `CAP_SYS_PTRACE`. Reduces exploitability of use-after-free via heap spray |
-| `vm.mmap_min_addr = 65536` | Prohibit mapping below 64K. Blocks null pointer dereference exploitation in the kernel |
+| `kernel.randomize_va_space = 2` | Full ASLR -- stack, heap, mmap, VDSO randomized. KSPP, DISA STIG |
+| `kernel.kptr_restrict = 2` | Hide kernel addresses from `/proc/kallsyms`, `/proc/modules` |
+| `kernel.dmesg_restrict = 1` | Block unprivileged dmesg access |
+| `kernel.yama.ptrace_scope = 1` | ptrace restricted to child processes. `gdb ./app` works; `strace -p <pid>` on unrelated process does not |
+| `kernel.perf_event_paranoid = 3` | Block perf counters for unprivileged users. Spectre mitigation (DISA STIG V-258076) |
+| `kernel.unprivileged_bpf_disabled = 1` | Block `bpf()` without `CAP_BPF`. CVE-2021-3490, CVE-2022-23222 |
+| `dev.tty.ldisc_autoload = 0` | Block TTY line discipline autoload. CVE-2017-2636 |
+| `vm.unprivileged_userfaultfd = 0` | Restrict `userfaultfd()` to `CAP_SYS_PTRACE`. Heap spray mitigation |
+| `vm.mmap_min_addr = 65536` | Prohibit mapping below 64K. Blocks null pointer dereference exploitation |
 
 ### Network hardening
 
 | Parameter | Effect |
 |---|---|
-| `net.core.bpf_jit_harden = 2` | BPF JIT constant blinding for all users. Protects against JIT spray attacks via eBPF |
-| `net.ipv4.conf.*.rp_filter = 1` | Reverse path filtering on **all** interfaces (wildcard applies to Docker/VPN created after boot). Prevents IP spoofing (CVE-2019-14899) |
+| `net.core.bpf_jit_harden = 2` | BPF JIT constant blinding for all users. JIT spray protection |
+| `net.ipv4.conf.all.rp_filter = 1` | Reverse path filtering on all + default interfaces. Prevents IP spoofing (CVE-2019-14899) |
 | `net.ipv4.tcp_syncookies = 1` | SYN cookie protection against SYN flood DDoS |
-| `net.ipv4.tcp_rfc1337 = 1` | Protect TIME_WAIT sockets against RST attacks (TIME_WAIT Assassination, RFC 1337) |
-| `net.ipv4.conf.*.accept_redirects = 0` | Block ICMP redirects. Prevents traffic hijacking via MITM router injection |
+| `net.ipv4.tcp_rfc1337 = 1` | Protect TIME_WAIT sockets against RST attacks (RFC 1337) |
+| `net.ipv4.conf.*.accept_redirects = 0` | Block ICMP redirects. Prevents traffic hijacking via MITM |
 | `net.ipv4.conf.*.send_redirects = 0` | Do not send ICMP redirects |
-| `net.ipv4.conf.*.accept_source_route = 0` | Block IPv4 source routing (forced routing through MITM) |
-| `net.ipv4.conf.all.log_martians = 1` | Log packets with impossible source/dest addresses (reconnaissance detection) |
+| `net.ipv4.conf.*.accept_source_route = 0` | Block IPv4 source routing |
+| `net.ipv4.conf.all.log_martians = 1` | Log packets with impossible addresses (reconnaissance detection) |
 | `net.ipv4.icmp_echo_ignore_broadcasts = 1` | Ignore broadcast ICMP echo (Smurf DDoS mitigation) |
 | `net.ipv4.tcp_timestamps = 0` | Hide uptime from fingerprinting. CIS 3.3.10. **Requires `tcp_tw_reuse = 0`** |
 | `net.ipv4.conf.all.arp_filter = 1` | ARP: do not respond through the wrong interface |
-| `net.ipv4.conf.all.arp_ignore = 2` | ARP: respond only if target IP belongs to this interface |
-| `net.ipv4.conf.all.drop_gratuitous_arp = 1` | Drop gratuitous ARP — primary vector for ARP cache poisoning and LAN MITM |
+| `net.ipv4.conf.all.arp_ignore = 1` | ARP: respond only if target IP belongs to receiving interface. Value `2` is stricter but breaks Docker/K8s/multi-IP VMs |
+| `net.ipv4.conf.all.drop_gratuitous_arp = 0` | Do not drop gratuitous ARP (default). Value `1` blocks ARP cache poisoning but breaks keepalived/VRRP HA |
 | `net.ipv6.conf.all.accept_redirects = 0` | Block ICMPv6 redirects |
 | `net.ipv6.conf.all.accept_source_route = 0` | Block IPv6 source routing |
-| `net.ipv6.conf.all.accept_ra = 0` | Reject IPv6 Router Advertisements. Rogue RA lets any host in the network become the default gateway (RFC 6104/6105) |
+| `net.ipv6.conf.all.accept_ra = 1` | Accept IPv6 Router Advertisements (kernel default). Required for SLAAC. Set `0` only with DHCPv6 stateful or static IPv6 |
 
 ### Filesystem hardening
 
 | Parameter | Effect |
 |---|---|
 | `fs.protected_hardlinks = 1` | Block hardlinks to files without read/write/ownership. TOCTOU mitigation |
-| `fs.protected_symlinks = 1` | Block following symlinks in world-writable sticky directories. Prevents `/tmp` race conditions |
-| `fs.protected_fifos = 2` | Block writes to FIFOs in sticky directories without ownership. TOCTOU mitigation |
+| `fs.protected_symlinks = 1` | Block following symlinks in world-writable sticky directories |
+| `fs.protected_fifos = 2` | Block writes to FIFOs in sticky directories without ownership |
 | `fs.protected_regular = 2` | Block writes to regular files in sticky directories without ownership |
-| `fs.suid_dumpable = 0` | Prohibit core dumps of SUID binaries. Passwords and keys can appear in setuid process dumps. CIS 1.6.4, DISA STIG V-230462 |
+| `fs.suid_dumpable = 0` | Prohibit core dumps of SUID binaries. CIS 1.6.4, DISA STIG V-230462 |
 
 ### Performance
 
 | Parameter | Purpose |
 |---|---|
-| `vm.swappiness = 10` | Minimize swap usage. Security: `1`, Performance: `10–60` |
-| `vm.vfs_cache_pressure = 50` | Reduce inode/dentry cache eviction aggressiveness |
-| `vm.dirty_ratio = 10` | Force flush when dirty pages reach 10% of RAM. For media servers (Plex/Jellyfin) with large libraries, raise to `20–40` to reduce write-stall pauses during transcoding |
-| `vm.dirty_background_ratio = 5` | Start background flush at 5% dirty pages. Raise to `10–15` alongside `dirty_ratio` for media workloads |
+| `vm.swappiness = 10` | Minimize swap usage |
+| `vm.vfs_cache_pressure = 50` | Reduce inode/dentry cache eviction |
+| `vm.dirty_ratio = 10` | Force flush when dirty pages reach 10% of RAM |
+| `vm.dirty_background_ratio = 5` | Start background flush at 5% dirty pages |
 | `fs.inotify.max_user_watches = 524288` | For IDEs (VSCode, JetBrains) and file watchers |
 | `fs.inotify.max_user_instances = 1024` | Max inotify instances per user |
-| `fs.file-max = 2097152` | System-wide open file descriptor limit. Note: applications (Plex, Jellyfin) also need per-process `LimitNOFILE` raised in their systemd unit — `fs.file-max` alone is not enough |
-| `net.core.somaxconn = 4096` | TCP connection backlog (for dev servers and Docker) |
-| `net.ipv4.tcp_fastopen = 3` | TCP Fast Open on client and server. Reduces latency on repeated connections |
+| `fs.file-max = 2097152` | System-wide open file descriptor limit |
+| `net.core.somaxconn = 4096` | TCP connection backlog |
+| `net.ipv4.tcp_fastopen = 3` | TCP Fast Open on client and server |
 
-## Requirements
+## Cross-platform details
 
-- Ansible 2.9 or higher
-- `become: true`
-- `gather_facts: true`
-- Supported OS families: `Archlinux`, `Debian`
+| Aspect | Arch Linux | Ubuntu / Debian | Fedora / RHEL | Void Linux | Gentoo |
+|--------|-----------|-----------------|---------------|------------|--------|
+| Package | `procps-ng` | `procps` | `procps-ng` | `procps-ng` | `procps` |
+| Config path | `/etc/sysctl.d/99-z-ansible.conf` | `/etc/sysctl.d/99-z-ansible.conf` | `/etc/sysctl.d/99-z-ansible.conf` | `/etc/sysctl.d/99-z-ansible.conf` | `/etc/sysctl.d/99-z-ansible.conf` |
+| Apport service | n/a | disabled if `suid_dumpable != 2` | n/a | n/a | n/a |
+| `kernel.unprivileged_userns_clone` | linux-hardened only | absent | absent | absent | absent |
+| Boot loader | `systemd-sysctl.service` | `systemd-sysctl.service` | `systemd-sysctl.service` | `sysctl` service (runit) | `sysctl` service (openrc) |
 
-## Role Variables
+## Logs
 
-### Feature toggles
+### Log files
 
-| Variable | Default | Description |
-|---|---|---|
-| `sysctl_security_enabled` | `true` | Master switch for all security parameters |
-| `sysctl_security_kernel_hardening` | `true` | Kernel: ASLR, kptr_restrict, eBPF, ptrace, mmap_min_addr |
-| `sysctl_security_network_hardening` | `true` | Network: ARP, ICMP, TCP, rp_filter, IPv6 |
-| `sysctl_security_filesystem_hardening` | `true` | FS: hardlink/symlink/FIFO/SUID protection |
-| `sysctl_security_ipv6_disable` | `false` | Fully disable IPv6 (caution: breaks DNS, Docker, Happy Eyeballs) |
+This role does not create its own log files. Kernel messages and sysctl behavior are logged through system logging.
 
-### Performance
+| Source | How to read | Contents |
+|--------|------------|----------|
+| syslog / journald | `journalctl -k` | Kernel messages including martian packet logs (`log_martians=1`) |
+| Ansible output | `ansible-playbook` stdout | Role execution report (install, configure, verify phases) |
+| Verify output | Role verify task debug messages | OK / MISMATCH / NOT SUPPORTED / ERROR per parameter |
 
-| Variable | Default | Description |
-|---|---|---|
-| `sysctl_vm_swappiness` | `10` | Swap aggressiveness |
-| `sysctl_vm_vfs_cache_pressure` | `50` | Cache eviction pressure |
-| `sysctl_vm_dirty_ratio` | `10` | Dirty page flush threshold (%) |
-| `sysctl_vm_dirty_background_ratio` | `5` | Background flush start (%) |
-| `sysctl_fs_inotify_max_user_watches` | `524288` | inotify watch limit |
-| `sysctl_fs_inotify_max_user_instances` | `1024` | inotify instance limit |
-| `sysctl_fs_file_max` | `2097152` | System open file descriptor limit |
-| `sysctl_net_core_somaxconn` | `4096` | TCP connection backlog |
-| `sysctl_net_ipv4_tcp_fastopen` | `3` | TCP Fast Open (0=off, 1=client, 2=server, 3=both) |
-| `sysctl_net_ipv4_tcp_tw_reuse` | `0` | TIME_WAIT socket reuse — **must be 0 when tcp_timestamps=0** |
+### Reading the logs
 
-### Security: Kernel
+- Martian packet detection: `journalctl -k --grep="martian"` -- look for spoofed packets
+- Sysctl load errors at boot: `journalctl -u systemd-sysctl` -- check for parameter rejection
+- Role verify results: run with `--tags sysctl,verify` and check debug output
 
-| Variable | Default | Description |
-|---|---|---|
-| `sysctl_kernel_randomize_va_space` | `2` | ASLR level (2=full) |
-| `sysctl_kernel_kptr_restrict` | `2` | Kernel pointer restriction (2=always hidden) |
-| `sysctl_kernel_dmesg_restrict` | `1` | Block unprivileged dmesg |
-| `sysctl_kernel_yama_ptrace_scope` | `1` | ptrace scope (1=child only, 2=root only) |
-| `sysctl_kernel_perf_event_paranoid` | `3` | perf event access (3=kernel-only) |
-| `sysctl_kernel_unprivileged_bpf_disabled` | `1` | Block unprivileged bpf() |
-| `sysctl_kernel_tty_ldisc_autoload` | `0` | Block TTY line discipline autoload |
-| `sysctl_vm_unprivileged_userfaultfd` | `0` | Restrict userfaultfd() |
-| `sysctl_vm_mmap_min_addr` | `65536` | Minimum mmap address |
-| `sysctl_kernel_unprivileged_userns_clone` | `1` | Arch linux-hardened kernel only — ignored on other kernels |
+## Troubleshooting
 
-### Security: Network
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| Role fails at "Assert supported operating system" | OS family not in supported list | Check `ansible_facts['os_family']` -- must be Archlinux, Debian, RedHat, Void, or Gentoo |
+| Verify shows MISMATCH for a parameter | Another sysctl.d file overrides our value after boot | Check `sysctl --system` output -- files are loaded alphabetically. Our `99-z-ansible.conf` should sort last. Remove conflicting files or rename them |
+| `kernel.unprivileged_userns_clone` shows NOT SUPPORTED | Parameter exists only in Arch `linux-hardened` kernel | Expected on standard kernels. The `-e` flag silently skips it. No action needed |
+| Docker containers cannot route traffic after role apply | `rp_filter=1` (strict) blocks Docker bridge | Add to `sysctl_custom_params`: `{name: "net.ipv4.conf.docker0.rp_filter", value: "2"}` |
+| `gdb --pid` or `strace -p` fails with EPERM | `ptrace_scope=1` restricts to child processes only | For debugging: temporarily `echo 0 > /proc/sys/kernel/yama/ptrace_scope`. Or set `sysctl_kernel_yama_ptrace_scope: 0` for gaming profile |
+| IPv6 connectivity lost after role apply | `sysctl_security_ipv6_disable: true` or `accept_ra: 0` | Set `sysctl_security_ipv6_disable: false` and `sysctl_net_ipv6_accept_ra: 1` (defaults) |
+| apport keeps resetting `fs.suid_dumpable` to 2 | apport.service starts after systemd-sysctl | Role should disable apport automatically. Check `systemctl is-enabled apport` |
+| Handler skipped in Docker | Sysctl params are read-only in containers | Expected behavior. Config file is still deployed; params apply on real boot |
 
-| Variable | Default | Description |
-|---|---|---|
-| `sysctl_net_core_bpf_jit_harden` | `2` | BPF JIT hardening (2=all users) |
-| `sysctl_net_ipv4_rp_filter` | `1` | Reverse path filter (applied as wildcard `*.rp_filter`) |
-| `sysctl_net_ipv4_tcp_syncookies` | `1` | SYN cookies |
-| `sysctl_net_ipv4_tcp_rfc1337` | `1` | TIME_WAIT assassination protection |
-| `sysctl_net_ipv4_accept_redirects` | `0` | Block ICMP redirects |
-| `sysctl_net_ipv4_send_redirects` | `0` | Do not send ICMP redirects |
-| `sysctl_net_ipv4_accept_source_route` | `0` | Block IPv4 source routing |
-| `sysctl_net_ipv4_log_martians` | `1` | Log martian packets |
-| `sysctl_net_ipv4_icmp_echo_ignore_broadcasts` | `1` | Ignore broadcast ICMP echo |
-| `sysctl_net_ipv4_icmp_ignore_bogus_error_responses` | `1` | Ignore bogus ICMP errors |
-| `sysctl_net_ipv4_tcp_timestamps` | `0` | Disable TCP timestamps |
-| `sysctl_net_ipv4_arp_filter` | `1` | ARP interface filter |
-| `sysctl_net_ipv4_arp_ignore` | `1` | ARP reply scope (1=safe for Docker/VM; 2=strict, bare-metal only) |
-| `sysctl_net_ipv4_drop_gratuitous_arp` | `0` | Drop gratuitous ARP (1 breaks keepalived/VRRP HA) |
-| `sysctl_net_ipv6_accept_redirects` | `0` | Block ICMPv6 redirects |
-| `sysctl_net_ipv6_accept_source_route` | `0` | Block IPv6 source routing |
-| `sysctl_net_ipv6_accept_ra` | `1` | Router Advertisements (0 breaks SLAAC IPv6; use 0 only with DHCPv6 stateful/static IPv6) |
+## Testing
 
-### Security: Filesystem
+Both scenarios are required for every role (TEST-002). Run Docker for fast feedback, Vagrant for full validation.
 
-| Variable | Default | Description |
-|---|---|---|
-| `sysctl_fs_protected_hardlinks` | `1` | Hardlink protection |
-| `sysctl_fs_protected_symlinks` | `1` | Symlink protection in sticky dirs |
-| `sysctl_fs_protected_fifos` | `2` | FIFO write protection in sticky dirs |
-| `sysctl_fs_protected_regular` | `2` | Regular file write protection in sticky dirs |
-| `sysctl_fs_suid_dumpable` | `0` | Prohibit SUID core dumps |
+| Scenario | Command | When to use | What it tests |
+|----------|---------|-------------|---------------|
+| Docker (fast) | `molecule test -s docker` | After changing variables, templates, or task logic | Config deployment, idempotence, file assertions (kernel params read-only in Docker) |
+| Vagrant (cross-platform) | `molecule test -s vagrant` | After changing OS-specific logic or security params | Real sysctl values, boot persistence, Arch + Ubuntu matrix |
 
-### Custom parameters
+### Success criteria
 
-| Variable | Default | Description |
-|---|---|---|
-| `sysctl_custom_params` | `[]` | Additional parameters: `[{name: "kernel.param", value: "1"}]` |
+- All steps complete: `syntax -> create -> prepare -> converge -> idempotence -> verify -> destroy`
+- Idempotence step: `changed=0` (second run changes nothing)
+- Verify step: all assertions pass with `success_msg` output
+- Final line: no `failed` tasks
+
+### What the tests verify
+
+| Category | Examples | Test requirement |
+|----------|----------|-----------------|
+| Packages | procps-ng/procps installed via `package_facts` | TEST-008 |
+| Config files | `/etc/sysctl.d/99-z-ansible.conf` exists, correct content, mode 0644, owned by root | TEST-008 |
+| Services | apport disabled on Debian (when applicable) | TEST-008 |
+| Runtime values | Live `sysctl -n` for 14 security + all performance params (Vagrant only) | TEST-008 |
+| Permissions | Config file mode 0644, owner root:root | TEST-008 |
+| Boot persistence | Reboot VM, re-verify all values survive systemd-sysctl reload (Vagrant only) | TEST-008 |
+| Cross-platform | `kernel.unprivileged_userns_clone` checked on Arch only; procps-ng vs procps | TEST-013 |
+
+### Common test failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `procps-ng package not found` | Stale package cache in container | Rebuild: `molecule destroy && molecule test -s docker` |
+| Idempotence failure on config deploy | Template produces different output on second run | Check for dynamic expressions in template (timestamps, random values) |
+| `Assertion failed` on live value check | Parameter not applied (Docker) or another file overrides | Docker: expected (live checks skipped). Vagrant: check sysctl.d file ordering |
+| Vagrant: `Python not found` on Arch | prepare.yml didn't run or bootstrap failed | Check `prepare.yml` imports `prepare-vagrant.yml`. Run full `molecule test -s vagrant` |
+| `apport.service not found` assertion fails | Running on Arch where apport doesn't exist | Assertion is guarded by `os_family == Debian`. If failing, check `gather_facts: true` |
 
 ## Tags
 
-| Tag | Purpose |
-|---|---|
-| `sysctl` | All tasks |
-| `sysctl`, `packages` | Package installation only |
-| `sysctl`, `configure` | Deploy drop-in config only |
-| `sysctl`, `verify` | Post-apply parameter verification only |
-
-## Example Playbook
-
-```yaml
-- name: Harden kernel parameters
-  hosts: all
-  become: true
-  gather_facts: true
-
-  roles:
-    - role: sysctl
-```
-
-Override for a development workstation:
-
-```yaml
-- role: sysctl
-  vars:
-    sysctl_kernel_yama_ptrace_scope: 1       # allow gdb ./app (default)
-    sysctl_net_ipv4_arp_ignore: 1            # less strict ARP in VM environments
-    sysctl_security_ipv6_disable: false      # keep IPv6 (default)
-```
-
-Override for maximum security (server):
-
-```yaml
-- role: sysctl
-  vars:
-    sysctl_vm_swappiness: 1                  # minimize sensitive data in swap
-    sysctl_kernel_yama_ptrace_scope: 2       # root-only ptrace
-    sysctl_security_ipv6_disable: true       # if no IPv6 connectivity
-```
-
-Run specific tasks:
+| Tag | What it runs | Use case |
+|-----|-------------|----------|
+| `sysctl` | Entire role | Full apply |
+| `sysctl`, `packages` | Package installation only | Ensure procps is installed |
+| `sysctl`, `configure` | Deploy drop-in config only | Re-deploy config without verify |
+| `sysctl`, `verify` | Post-apply verification only | Check live values without deploying |
+| `sysctl`, `services` | Service management only | Disable apport |
+| `sysctl`, `report` | Execution report only | Re-generate execution report |
 
 ```bash
+# Full apply
+ansible-playbook playbook.yml --tags sysctl
+
 # Deploy config and verify only
 ansible-playbook playbook.yml --tags sysctl,configure,verify
 
@@ -203,53 +312,22 @@ ansible-playbook playbook.yml --tags sysctl,configure,verify
 ansible-playbook playbook.yml --tags sysctl,verify
 ```
 
-## Files deployed
+## File map
 
-- `/etc/sysctl.d/99-z-ansible.conf` — drop-in kernel parameter configuration, loaded automatically at boot by `systemd-sysctl.service` and on-demand via `sysctl --system`
-
-## Testing
-
-### Scenarios
-
-| Scenario | Driver | Platforms | What is tested |
-|---|---|---|---|
-| `default` | localhost | Developer's Arch Linux machine | File deployment + live sysctl values |
-| `docker` | Docker | Arch Linux (arch-systemd image) | File deployment only (sysctl namespace restricted in containers) |
-| `vagrant` | Vagrant + libvirt | Arch Linux, Ubuntu 24.04 | Full: file deployment + live values on both distros |
-
-### Running tests
-
-```bash
-# Localhost (requires running on Arch Linux)
-molecule test -s default
-
-# Docker (requires Docker + arch-systemd image)
-molecule test -s docker
-
-# Vagrant (requires libvirt + vagrant)
-molecule test -s vagrant
-```
-
-### Test structure
-
-```
-molecule/
-  shared/
-    converge.yml   # Role application (all scenarios)
-    verify.yml     # Assertions (file + live values, with container guards)
-  default/
-    molecule.yml   # Localhost scenario config
-  docker/
-    molecule.yml   # Docker scenario config
-    prepare.yml    # Update pacman cache
-  vagrant/
-    molecule.yml   # Vagrant KVM scenario config (Arch + Ubuntu)
-```
-
-Verification is split into three tiers:
-1. **File checks** (all scenarios): `/etc/sysctl.d/99-z-ansible.conf` exists, correct ownership/permissions, required parameters present
-2. **Live value checks** (skipped in Docker): Live `sysctl -n` values match expected values for performance, kernel hardening, network hardening, and filesystem hardening parameters
-3. **Cross-platform checks**: Arch-specific parameters (`kernel.unprivileged_userns_clone`) verified on Arch only
+| File | Purpose | Edit? |
+|------|---------|-------|
+| `defaults/main.yml` | All configurable settings with inline comments | No -- override via inventory |
+| `vars/main.yml` | Internal bridge vars, OS-family package mappings | Only when adding distro support |
+| `templates/sysctl.conf.j2` | Drop-in sysctl config template with KSPP/CIS/STIG references | When changing parameter structure |
+| `tasks/main.yml` | Execution flow orchestrator | When adding/removing steps |
+| `tasks/packages.yml` | Package installation | Rarely |
+| `tasks/services.yml` | Apport disable + outcome logging | Rarely |
+| `tasks/deploy.yml` | Config file deployment | When changing deploy logic |
+| `tasks/verify.yml` | Post-deploy self-check (14 parameters) | When changing verification logic |
+| `tasks/report.yml` | Structured execution report | When changing report format |
+| `handlers/main.yml` | `reload sysctl` handler | Rarely |
+| `meta/main.yml` | Galaxy metadata, platform list | When changing supported platforms |
+| `molecule/` | Test scenarios (docker, vagrant, default) | When changing test coverage |
 
 ## Compliance
 
@@ -261,25 +339,15 @@ Verification is split into three tiers:
 
 ## Notes
 
-**`tcp_timestamps` and `tcp_tw_reuse` are linked.** `tcp_tw_reuse = 1` is unsafe when `tcp_timestamps = 0` — the kernel uses timestamps to distinguish new connections from duplicate packets from old TIME_WAIT sockets. Both are set conservatively here: `tcp_timestamps = 0`, `tcp_tw_reuse = 0`.
+**`tcp_timestamps` and `tcp_tw_reuse` are linked.** `tcp_tw_reuse = 1` is unsafe when `tcp_timestamps = 0` -- the kernel uses timestamps to distinguish new connections from duplicate packets. Both are set conservatively: `tcp_timestamps = 0`, `tcp_tw_reuse = 0`.
 
-**`kernel.unprivileged_userns_clone`** exists only in the Arch `linux-hardened` kernel. On standard upstream kernels (Arch and Debian), it is absent. The `-e` flag in the handler ensures it is silently skipped.
+**`kernel.unprivileged_userns_clone`** exists only in the Arch `linux-hardened` kernel. On standard upstream kernels, it is absent. The `-e` flag in the handler ensures it is silently skipped.
 
-**`arp_ignore` default is `1`** (reply only if target IP belongs to receiving interface). Value `2` is stricter but breaks Docker bridge networking, Kubernetes VIPs, and multi-IP VMs. Kicksecure rolled back from `2` to `1` ([PR #290](https://github.com/Kicksecure/security-misc/pull/290)). Use `2` only on bare-metal single-NIC servers without Docker.
+**`arp_ignore` default is `1`** (reply only if target IP belongs to receiving interface). Value `2` is stricter but breaks Docker bridge networking, Kubernetes VIPs, and multi-IP VMs. Kicksecure rolled back from `2` to `1` ([PR #290](https://github.com/Kicksecure/security-misc/pull/290)).
 
-**`drop_gratuitous_arp` default is `0`**. Value `1` blocks ARP cache poisoning but breaks `keepalived`/VRRP HA failover — backup servers cannot announce virtual IP takeover. Enable only on non-HA workstations: `sysctl_net_ipv4_drop_gratuitous_arp: 1`.
+**`rp_filter` uses `conf.all` + `conf.default`** (not wildcard `*`). The wildcard would override Docker bridge interfaces which require `rp_filter=2` (loose) or `0`.
 
-**`rp_filter` uses `conf.all` + `conf.default`** (not wildcard `*`). The wildcard would override Docker bridge interfaces (`docker0`, `br-*`) which require `rp_filter=2` (loose) or `0` to route container traffic correctly. For Docker hosts, add to `sysctl_custom_params`:
-```yaml
-sysctl_custom_params:
-  - { name: "net.ipv4.conf.docker0.rp_filter", value: "2" }
-```
-
-**`accept_ra` default is `1`** (accept Router Advertisements, kernel default). Setting `0` disables SLAAC — IPv6 connectivity is lost on networks without DHCPv6 stateful, which is the majority of home/office/cloud networks. Disable only on servers with static IPv6 or DHCPv6 stateful: `sysctl_net_ipv6_accept_ra: 0`.
-
-**Gaming: `tcp_timestamps = 0` and port exhaustion.** Disabling timestamps has negligible effect on game latency. However, the paired `tcp_tw_reuse = 0` means TIME_WAIT sockets are not recycled. Under heavy connection workloads (game launchers, CDN patch downloads making 1000+ short TCP connections/min), ephemeral port exhaustion can occur. Override to `sysctl_net_ipv4_tcp_tw_reuse: 1` only if `tcp_timestamps` is also re-enabled.
-
-**Post-apply verification** reads live values via `sysctl -n` and reports `OK`, `MISMATCH`, `NOT SUPPORTED` (kernel version too old), or `ERROR` for each checked parameter. Parameters unsupported by the current kernel are skipped without error.
+**Workstation profiles**: `sysctl_kernel_yama_ptrace_scope` is profile-aware. With `workstation_profiles: [gaming]` it defaults to `0` (Wine/Proton need this). With `[security]` it defaults to `2`. Otherwise `1`.
 
 ## License
 

--- a/ansible/roles/sysctl/defaults/main.yml
+++ b/ansible/roles/sysctl/defaults/main.yml
@@ -6,6 +6,9 @@
 sysctl_supported_os:
   - Archlinux
   - Debian
+  - RedHat
+  - Void
+  - Gentoo
 
 # ---- VM / Memory ----
 sysctl_vm_swappiness: 10
@@ -53,9 +56,14 @@ sysctl_kernel_kptr_restrict: 2
 # Ограничить dmesg для непривилегированных пользователей. KSPP=yes
 sysctl_kernel_dmesg_restrict: 1
 
+# ptrace: 0=no restrictions (gaming, Wine/Proton needs this)
 # ptrace: 1=только child-процессы (dev, gdb ./app работает)
 # ptrace: 2=только root (ломает gdb --pid=, strace -p, perf record -p)
-sysctl_kernel_yama_ptrace_scope: 1
+# Profile-aware: gaming=0, developer=1, security=2, default=1
+sysctl_kernel_yama_ptrace_scope: >-
+  {{ 0 if 'gaming' in (workstation_profiles | default([]))
+     else (2 if 'security' in (workstation_profiles | default([]))
+     else 1) }}
 
 # Ограничить доступ к perf counters (Spectre side-channel). KSPP=yes. DISA STIG V-258076
 sysctl_kernel_perf_event_paranoid: 3

--- a/ansible/roles/sysctl/meta/main.yml
+++ b/ansible/roles/sysctl/meta/main.yml
@@ -10,5 +10,11 @@ galaxy_info:
       versions: [all]
     - name: Debian
       versions: [all]
+    - name: EL
+      versions: [all]
+    - name: Void Linux
+      versions: [all]
+    - name: Gentoo
+      versions: [all]
   galaxy_tags: [sysctl, kernel, tuning, performance]
 dependencies: []

--- a/ansible/roles/sysctl/molecule/shared/converge.yml
+++ b/ansible/roles/sysctl/molecule/shared/converge.yml
@@ -5,4 +5,4 @@
   gather_facts: true
 
   roles:
-    - role: sysctl
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/ansible/roles/sysctl/molecule/vagrant/molecule.yml
+++ b/ansible/roles/sysctl/molecule/vagrant/molecule.yml
@@ -26,6 +26,7 @@ provisioner:
   env:
     ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
   playbooks:
+    prepare: prepare.yml
     converge: ../shared/converge.yml
     verify: ../shared/verify.yml
 
@@ -36,6 +37,7 @@ scenario:
   test_sequence:
     - syntax
     - create
+    - prepare
     - converge
     - idempotence
     - verify

--- a/ansible/roles/sysctl/tasks/main.yml
+++ b/ansible/roles/sysctl/tasks/main.yml
@@ -3,6 +3,16 @@
 # Каждый import_tasks = одна бизнес-функция роли.
 # SRP: main.yml — только оркестратор.
 
+- name: Assert supported operating system
+  ansible.builtin.assert:
+    that:
+      - ansible_facts['os_family'] in _sysctl_supported_os
+    fail_msg: >-
+      OS family '{{ ansible_facts['os_family'] }}' is not supported.
+      Supported: {{ _sysctl_supported_os | join(', ') }}
+    success_msg: "OS family '{{ ansible_facts['os_family'] }}' is supported"
+  tags: ['sysctl']
+
 - name: Install required packages
   ansible.builtin.import_tasks: packages.yml
   when: ansible_facts['os_family'] in _sysctl_supported_os

--- a/ansible/roles/sysctl/tasks/packages.yml
+++ b/ansible/roles/sysctl/tasks/packages.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure procps is installed
   ansible.builtin.package:
-    # Arch Linux: procps-ng (пакет называется иначе, чем на Debian/Ubuntu)
-    name: "{{ 'procps-ng' if ansible_facts['os_family'] == 'Archlinux' else 'procps' }}"
+    # Arch/Void/Gentoo: procps-ng; Debian/RedHat: procps
+    name: "{{ _sysctl_procps_package[ansible_facts['os_family']] | default('procps') }}"
     state: present
   tags: ['sysctl', 'packages']

--- a/ansible/roles/sysctl/tasks/report.yml
+++ b/ansible/roles/sysctl/tasks/report.yml
@@ -1,13 +1,59 @@
 ---
 # === sysctl: report ===
+# Structured execution report via common/report_phase + report_render
 
-- name: Report sysctl configuration
-  ansible.builtin.debug:
-    msg:
-      - "sysctl drop-in: /etc/sysctl.d/99-z-ansible.conf"
-      - "vm.swappiness={{ sysctl_vm_swappiness }}"
-      - "fs.inotify.max_user_watches={{ sysctl_fs_inotify_max_user_watches }}"
-      - "net.core.somaxconn={{ sysctl_net_core_somaxconn }}"
-      - "Security hardening: {{ 'включён' if sysctl_security_enabled else 'выключен' }}"
-      - "Custom params: {{ sysctl_custom_params | length }}"
-  tags: ['sysctl']
+- name: "Report: Install packages"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_sysctl_phases"
+    common_rpt_phase: "Install packages"
+    common_rpt_detail: >-
+      {{ _sysctl_procps_package[ansible_facts['os_family']] | default('procps') }}
+  tags: ['sysctl', 'report']
+
+- name: "Report: Manage services"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_sysctl_phases"
+    common_rpt_phase: "Manage services"
+    common_rpt_detail: >-
+      apport={{ 'disabled' if (ansible_facts['os_family'] == 'Debian'
+        and sysctl_security_enabled | bool
+        and sysctl_security_filesystem_hardening | bool) else 'n/a' }}
+  tags: ['sysctl', 'report']
+
+- name: "Report: Deploy configuration"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_sysctl_phases"
+    common_rpt_phase: "Deploy configuration"
+    common_rpt_detail: >-
+      /etc/sysctl.d/99-z-ansible.conf
+      security={{ sysctl_security_enabled }}
+  tags: ['sysctl', 'report']
+
+- name: "Report: Verify parameters"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_sysctl_phases"
+    common_rpt_phase: "Verify parameters"
+    common_rpt_detail: >-
+      live sysctl -n checks
+  tags: ['sysctl', 'report']
+
+- name: "sysctl -- Execution Report"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_render.yml
+  vars:
+    common_rpt_fact: "_sysctl_phases"
+    common_rpt_title: "sysctl"
+  tags: ['sysctl', 'report']

--- a/ansible/roles/sysctl/tasks/report.yml
+++ b/ansible/roles/sysctl/tasks/report.yml
@@ -49,7 +49,7 @@
       live sysctl -n checks
   tags: ['sysctl', 'report']
 
-- name: "sysctl -- Execution Report"
+- name: "Sysctl -- Execution Report"
   ansible.builtin.include_role:
     name: common
     tasks_from: report_render.yml

--- a/ansible/roles/sysctl/tasks/services.yml
+++ b/ansible/roles/sysctl/tasks/services.yml
@@ -13,10 +13,24 @@
     name: apport
     state: stopped
     enabled: false
+  register: _sysctl_apport_result
   when:
     - ansible_facts['os_family'] == 'Debian'
     - sysctl_security_enabled | bool
     - sysctl_security_filesystem_hardening | bool
     - sysctl_fs_suid_dumpable | int != 2
   failed_when: false
+  tags: ['sysctl', 'services']
+
+- name: Report apport disable outcome
+  ansible.builtin.debug:
+    msg: >-
+      apport service {{ 'disabled successfully' if (_sysctl_apport_result is not failed)
+      else 'not found or already disabled — this is expected if apport is not installed' }}
+  when:
+    - ansible_facts['os_family'] == 'Debian'
+    - _sysctl_apport_result is defined
+    - sysctl_security_enabled | bool
+    - sysctl_security_filesystem_hardening | bool
+    - sysctl_fs_suid_dumpable | int != 2
   tags: ['sysctl', 'services']

--- a/ansible/roles/sysctl/vars/main.yml
+++ b/ansible/roles/sysctl/vars/main.yml
@@ -4,3 +4,11 @@
 # to the public defaults, following project convention.
 
 _sysctl_supported_os: "{{ sysctl_supported_os }}"
+
+# Package name mapping per OS family
+_sysctl_procps_package:
+  Archlinux: procps-ng
+  Debian: procps
+  RedHat: procps-ng
+  Void: procps-ng
+  Gentoo: procps

--- a/wiki/roles/sysctl.md
+++ b/wiki/roles/sysctl.md
@@ -1,0 +1,98 @@
+# Роль: sysctl
+
+**Phase**: 1 | **Направление**: Система
+
+## Цель
+
+Настройка параметров ядра Linux через `/etc/sysctl.d/99-z-ansible.conf` для трёх целей: hardening ядра (ASLR, ptrace, eBPF), уменьшение сетевой attack surface (ARP, ICMP, rp_filter, IPv6), оптимизация производительности рабочей станции (swappiness, inotify, somaxconn). Параметры применяются distribution-agnostic через `sysctl -e --system`.
+
+## Ключевые переменные (defaults)
+
+```yaml
+sysctl_security_enabled: true                    # Мастер-переключатель всех security параметров
+sysctl_security_kernel_hardening: true           # Kernel: ASLR, kptr_restrict, eBPF, ptrace
+sysctl_security_network_hardening: true          # Network: ARP, ICMP, TCP, rp_filter, IPv6
+sysctl_security_filesystem_hardening: true       # FS: hardlink/symlink/FIFO/SUID protection
+sysctl_security_ipv6_disable: false              # Полностью отключить IPv6 (осторожно!)
+
+sysctl_vm_swappiness: 10                         # Агрессивность swap
+sysctl_fs_inotify_max_user_watches: 524288       # Для IDE и file watchers
+sysctl_net_core_somaxconn: 4096                  # TCP backlog
+sysctl_kernel_yama_ptrace_scope: 1               # Profile-aware: gaming=0, dev=1, security=2
+
+sysctl_custom_params: []                         # Дополнительные параметры [{name, value}]
+```
+
+## Что настраивает
+
+- Конфигурационные файлы:
+  - `/etc/sysctl.d/99-z-ansible.conf` -- drop-in конфигурация, загружается при boot через `systemd-sysctl.service`
+- Сервисы:
+  - `apport.service` (Ubuntu) -- disabled, если `fs.suid_dumpable != 2` (apport перезаписывает значение после boot)
+- Пакеты:
+  - `procps-ng` (Arch/Void/Gentoo) или `procps` (Debian/RedHat) -- утилиты sysctl
+
+**Все платформы:** Archlinux, Debian, RedHat, Void, Gentoo
+
+## Audit Events
+
+| Событие | Источник | Severity | Threshold |
+|---------|----------|----------|-----------|
+| sysctl parameter mismatch after boot | `sysctl -n` vs config file | CRITICAL | any deviation from expected value |
+| ASLR disabled (`randomize_va_space != 2`) | `/proc/sys/kernel/randomize_va_space` | CRITICAL | value < 2 |
+| ptrace scope relaxed (`ptrace_scope = 0`) | `/proc/sys/kernel/yama/ptrace_scope` | WARNING | value = 0 on non-gaming profile |
+| SYN cookies disabled | `/proc/sys/net/ipv4/tcp_syncookies` | CRITICAL | value = 0 |
+| Reverse path filter disabled | `/proc/sys/net/ipv4/conf/all/rp_filter` | WARNING | value = 0 |
+| ICMP redirects accepted | `/proc/sys/net/ipv4/conf/all/accept_redirects` | WARNING | value != 0 |
+| Core dump of SUID allowed | `/proc/sys/fs/suid_dumpable` | WARNING | value > 0 |
+| apport re-enabled after role apply | `systemctl is-enabled apport` | WARNING | enabled on Debian with suid_dumpable hardening |
+| Config file tampered | `stat /etc/sysctl.d/99-z-ansible.conf` | CRITICAL | mode != 0644, owner != root |
+| Another sysctl.d file overrides values | `sysctl --system` output | WARNING | file sorting after 99-z-ansible.conf |
+
+## Monitoring Integration
+
+- **Drift detection**: re-run role with `--tags sysctl,verify` -- compares live values to expected
+- **node_exporter textfile**: export key sysctl values via textfile collector for Prometheus
+- **Prometheus metric (proposed)**: `sysctl_param_value{param="kernel.randomize_va_space"}` via custom collector
+- **Alert rule (proposed)**: `SysctlDrift` -- fires when live value differs from config for > 5m after boot
+
+### Рекомендуемые Prometheus alerts
+
+```yaml
+groups:
+  - name: sysctl_monitoring
+    interval: 300s
+    rules:
+      - alert: SysctlASLRDisabled
+        expr: sysctl_param_value{param="kernel.randomize_va_space"} < 2
+        for: 5m
+        annotations:
+          summary: "ASLR disabled on {{ $labels.instance }}"
+          runbook: "wiki/runbooks/sysctl-aslr.md"
+
+      - alert: SysctlSynCookiesDisabled
+        expr: sysctl_param_value{param="net.ipv4.tcp_syncookies"} == 0
+        for: 5m
+        annotations:
+          summary: "SYN cookies disabled on {{ $labels.instance }}"
+```
+
+## Зависимости
+
+- Нет зависимостей (`meta/main.yml: dependencies: []`)
+- `common` (для report_phase/report_render) -- включается через `include_role`
+
+**Рекомендуется размещение:** Phase 1 (kernel параметры критичны для безопасности всех последующих ролей)
+
+## Tags
+
+- `sysctl` -- все задачи
+- `sysctl`, `packages` -- только установка пакетов
+- `sysctl`, `configure` -- только деплой конфигурации
+- `sysctl`, `verify` -- только проверка live значений
+- `sysctl`, `services` -- управление сервисами (apport)
+- `sysctl`, `report` -- execution report
+
+---
+
+Назад к [[Roadmap]]


### PR DESCRIPTION
## Summary

- **ROLE-003**: Add preflight `assert` for OS family + expand `sysctl_supported_os` to all 5 required families (Archlinux, Debian, RedHat, Void, Gentoo)
- **ROLE-008**: Replace simple `debug` report with structured `common/report_phase` + `report_render` integration
- **ROLE-007**: Create `wiki/roles/sysctl.md` with Audit Events table and Monitoring Integration section
- **ROLE-009**: Make `ptrace_scope` profile-aware (`gaming=0`, `developer=1`, `security=2`) via `workstation_profiles`
- **ROLE-013**: Add downstream `debug` logging after `apport` `failed_when: false`
- **README**: Full rewrite complying with README-001 through README-010 (execution flow, safety levels, cross-platform, logs, troubleshooting, testing criteria, file map)
- **CI-004**: Add `timeout-minutes: 15` to Docker molecule job
- **TEST-006**: Dynamic role name in `converge.yml` via `MOLECULE_PROJECT_DIRECTORY`
- **P0**: Fix 3 incorrect values in README tables (`arp_ignore=2->1`, `drop_gratuitous_arp=1->0`, `accept_ra=0->1`)
- **Vagrant**: Add explicit `prepare` step to `test_sequence` + playbook reference

## Test plan

- [ ] `molecule test -s docker` passes for sysctl role (config deployment, idempotence)
- [ ] `molecule test -s vagrant` passes for sysctl role (live values, boot persistence, cross-platform)
- [ ] Lint passes (`yamllint` + `ansible-lint`)
- [ ] Preflight assert correctly fails on unsupported OS families
- [ ] Report output shows structured table format (not plain debug)
- [ ] README variables table matches `defaults/main.yml` 1:1

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)