### PR TITLE
fix(docker): add ROLE-008 reporting and rewrite README per standards

### DIFF
--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -1,77 +1,198 @@
 # docker
 
-Docker daemon configuration with CIS-hardened defaults (daemon.json, service, user group).
+Configures Docker daemon with CIS-hardened defaults (daemon.json, service management, user group membership).
 
-## What this role does
+## Execution flow
 
-- [x] Creates `/etc/docker/` directory with correct ownership (root:root 0755)
-- [x] Builds `docker_daemon_config` dict via `set_fact` (conditionally merges security settings)
-- [x] Deploys `/etc/docker/daemon.json` from Jinja2 template with JSON validation (`python3 -m json.tool`)
-- [x] Ensures `docker` group exists and adds the target user to it
-- [x] Enables and starts the `docker` service (skippable via `docker_enable_service: false`)
-- [x] Restarts Docker on config change via handler
+1. **Preflight** (`tasks/main.yml`) -- asserts OS family is in the supported list (`Archlinux`, `Debian`, `RedHat`, `Void`, `Gentoo`); fails immediately if unsupported
+2. **Load OS variables** (`vars/<os_family>.yml`) -- loads distro-specific service name (`_docker_service_name`)
+3. **Create config directory** -- ensures `/etc/docker/` exists with `root:root 0755`
+4. **Build daemon config** -- assembles `docker_daemon_config` dict via `set_fact`, conditionally merging security settings (`userns-remap`, `icc`, `live-restore`, `no-new-privileges`) and storage driver
+5. **Deploy daemon.json** -- renders `/etc/docker/daemon.json` from Jinja2 template with JSON validation (`python3 -m json.tool`). **Triggers handler:** if config changed, Docker will be restarted.
+6. **User group** -- ensures `docker` group exists and adds `docker_user` to it (skipped when `docker_add_user_to_group: false`)
+7. **Service** -- enables and starts Docker service (skipped when `docker_enable_service: false`)
+8. **Verify** (`tasks/verify.yml`) -- checks `/etc/docker/` permissions, `daemon.json` validity (JSON parse), correct ownership and mode
+9. **Report** -- writes execution report via `common/report_phase` + `report_render`
+
+### Handlers
+
+| Handler | Triggered by | What it does |
+|---------|-------------|-------------|
+| `Restart docker` | Config file change (step 5) | Restarts Docker service via `ansible.builtin.service`. Skipped when `docker_enable_service: false`. |
 
 ## Variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `docker_user` | `SUDO_USER` → `user_id` | User to add to the `docker` group |
-| `docker_add_user_to_group` | `true` | Whether to add the user to `docker` group |
-| `docker_enable_service` | `true` | Enable and start the Docker service |
-| `docker_log_driver` | `"journald"` | Logging driver for containers |
-| `docker_log_max_size` | `"10m"` | Max log file size (non-journald drivers) |
-| `docker_log_max_file` | `"3"` | Max number of log files (non-journald drivers) |
-| `docker_storage_driver` | `""` | Storage driver (empty = use Docker default) |
-| `docker_userns_remap` | `"default"` | User namespace remapping (CIS: isolates container UIDs from host) |
-| `docker_icc` | `false` | Inter-container communication via docker0 (CIS: disable) |
-| `docker_live_restore` | `true` | Keep containers running when dockerd restarts |
-| `docker_no_new_privileges` | `true` | Block setuid privilege escalation in containers |
+### Configurable (`defaults/main.yml`)
 
-## Security defaults
+Override these via inventory (`group_vars/` or `host_vars/`), never edit `defaults/main.yml` directly.
 
-All security variables ship with CIS Docker Benchmark values enabled:
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `docker_user` | `SUDO_USER` or `user_id` | safe | User to add to the `docker` group. Detected automatically from the invoking user |
+| `docker_add_user_to_group` | `true` | careful | Add `docker_user` to `docker` group. Equivalent to root access -- only enable for trusted users |
+| `docker_enable_service` | `true` | safe | Enable and start the Docker service. Set `false` for config-only runs or container testing |
+| `docker_log_driver` | `"journald"` | safe | Container logging driver. Common values: `journald`, `json-file`, `syslog` |
+| `docker_log_max_size` | `"10m"` | safe | Max log file size per container (only applies to `json-file` and `local` drivers) |
+| `docker_log_max_file` | `"3"` | safe | Max number of rotated log files per container (only applies to `json-file` and `local` drivers) |
+| `docker_storage_driver` | `""` | careful | Storage driver override. Empty = Docker auto-selects (usually `overlay2`). Changing on existing installs may require data migration |
+| `docker_userns_remap` | `"default"` | careful | User namespace remapping. Isolates container UIDs from host. Breaks bind-mount permissions -- use named volumes or `chown 100000:100000` |
+| `docker_icc` | `false` | careful | Inter-container communication via `docker0` bridge. `false` = containers must use user-defined networks (Docker Compose creates them automatically) |
+| `docker_live_restore` | `true` | safe | Keep containers running when dockerd restarts. Incompatible with Docker Swarm |
+| `docker_no_new_privileges` | `true` | safe | Block setuid privilege escalation in containers. Per-container override: `--security-opt no-new-privileges=false` |
 
-| Setting | Value | CIS Control |
-|---------|-------|-------------|
-| `userns-remap` | `"default"` | Isolates container UIDs from host UIDs |
-| `icc` | `false` | Disables direct inter-container communication |
-| `live-restore` | `true` | Daemon resilience without stopping containers |
-| `no-new-privileges` | `true` | Prevents privilege escalation via setuid |
+### Internal mappings (`vars/`)
 
-> **Note on userns-remap:** Requires `CONFIG_USER_NS=y` kernel support (enabled on Arch and Ubuntu 24.04).
-> Volume permissions: use named volumes or `chown 100000:100000` on host bind-mount directories.
+These files contain cross-platform mappings. Do not override via inventory -- edit the files directly only when adding new platform support.
+
+| File | What it contains | When to edit |
+|------|-----------------|-------------|
+| `vars/archlinux.yml` | Service name for Arch Linux (`docker`) | Adding Arch-specific overrides |
+| `vars/debian.yml` | Service name for Debian/Ubuntu (`docker`) | Adding Debian-specific overrides |
+| `vars/redhat.yml` | Service name for Fedora/RHEL (`docker`) | Adding RedHat-specific overrides |
+| `vars/void.yml` | Service name for Void Linux (`docker`) | Adding Void-specific overrides |
+| `vars/gentoo.yml` | Service name for Gentoo (`docker`) | Adding Gentoo-specific overrides |
+
+## Examples
+
+### Changing the log driver
+
+```yaml
+# In group_vars/all/docker.yml or host_vars/<hostname>/docker.yml:
+docker_log_driver: "json-file"
+docker_log_max_size: "50m"
+docker_log_max_file: "5"
+```
+
+- `journald` (default) -- logs go to systemd journal, searchable via `journalctl CONTAINER_NAME=...`
+- `json-file` -- logs stored as JSON files in `/var/lib/docker/containers/<id>/`, rotated by `max-size`/`max-file`
+
+### Disabling security hardening for development
+
+```yaml
+# In host_vars/<dev-workstation>/docker.yml:
+docker_userns_remap: ""          # disable user namespace remapping
+docker_icc: true                 # allow inter-container communication
+docker_no_new_privileges: false  # allow setuid in containers
+```
+
+### Skipping user group membership
+
+```yaml
+# In host_vars/<hostname>/docker.yml:
+docker_add_user_to_group: false
+```
+
+Docker commands will require `sudo`. Safer for shared or production-like machines.
+
+### Config-only run (no service management)
+
+```yaml
+# In host_vars/<hostname>/docker.yml:
+docker_enable_service: false
+```
+
+Or use tags: `ansible-playbook playbook.yml --tags docker:configure`
+
+## Cross-platform details
+
+| Aspect | Arch Linux | Ubuntu / Debian | Fedora / RHEL | Void Linux | Gentoo |
+|--------|-----------|-----------------|---------------|------------|--------|
+| Service name | `docker` | `docker` | `docker` | `docker` | `docker` |
+| Package name | `docker` | `docker.io` | `docker` | `docker` | `app-containers/docker` |
+| Config path | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` |
+
+The config path is identical across all distros. Package names differ -- this role does not install Docker, so the package name is only relevant to the prepare step in molecule tests.
+
+## Logs
+
+### Log files
+
+| File | Path | Contents | Rotation |
+|------|------|----------|----------|
+| Container logs (journald) | `journalctl CONTAINER_NAME=<name>` | Container stdout/stderr | System journal rotation |
+| Container logs (json-file) | `/var/lib/docker/containers/<id>/<id>-json.log` | Container stdout/stderr as JSON | `docker_log_max_size` / `docker_log_max_file` |
+| Docker daemon | `journalctl -u docker` | Daemon start/stop, errors, warnings | System journal rotation |
+| daemon.json | `/etc/docker/daemon.json` | Not a log -- config file deployed by this role | N/A |
+
+### Reading the logs
+
+- Daemon issues: `journalctl -u docker -n 50 --no-pager`
+- Container logs: `docker logs <container>` or `journalctl CONTAINER_NAME=<name>`
+- Live-restore events: `journalctl -u docker | grep live-restore`
+
+## Troubleshooting
+
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| Role fails at "Assert supported operating system" | OS family not in supported list | Check `ansible_facts['os_family']` -- must be one of: Archlinux, Debian, RedHat, Void, Gentoo |
+| `daemon.json` validation fails | Invalid JSON syntax in merged config | Run `python3 -m json.tool /etc/docker/daemon.json` to see the error. Check variable values for unquoted strings |
+| Docker won't start after config change | Bad daemon.json or conflicting settings | `journalctl -u docker -n 50`. Common: `userns-remap` with incompatible storage driver |
+| Containers can't talk to each other | `docker_icc: false` blocks `docker0` traffic | Use user-defined networks (`docker network create mynet`) or set `docker_icc: true` |
+| Bind-mount permission denied | `userns-remap` shifts UIDs by 100000 | Use named volumes, or `chown 100000:100000` on host directories, or disable `docker_userns_remap: ""` |
+| User can't run `docker` commands | Not in docker group, or session not refreshed | Check: `id -nG <user>`. If `docker` missing: verify `docker_add_user_to_group: true`. Log out and back in for group changes to take effect |
+| Handler didn't restart Docker | `docker_enable_service: false` skips handler | Set `docker_enable_service: true` or restart manually: `systemctl restart docker` |
+
+## Testing
+
+Both scenarios are required for every role (TEST-002). Run Docker for fast feedback, Vagrant for full validation.
+
+| Scenario | Command | When to use | What it tests |
+|----------|---------|-------------|---------------|
+| Docker (fast) | `molecule test -s docker` | After changing variables, templates, or task logic | Config deployment, idempotence, daemon.json content, negative-path assertions |
+| Vagrant (cross-platform) | `molecule test -s vagrant` | After changing OS-specific logic, services, or security settings | Real systemd, real packages, Arch + Ubuntu matrix, service state, runtime `docker info` |
+
+### Success criteria
+
+- All steps complete: `syntax -> converge -> idempotence -> verify -> destroy`
+- Idempotence step: `changed=0` (second run changes nothing)
+- Verify step: all assertions pass with `success_msg` output
+- Final line: no `failed` tasks
+
+### What the tests verify
+
+| Category | Examples | Test requirement |
+|----------|----------|-----------------|
+| Directory | `/etc/docker/` exists with `root:root 0755` | TEST-008 |
+| Config file | `daemon.json` exists with `root:root 0644`, valid JSON | TEST-008 |
+| Config content | `log-driver`, `log-opts`, security keys match variables | TEST-008 |
+| Group | `docker` group exists, user is member | TEST-008 |
+| Service | `docker.service` enabled + running (vagrant only) | TEST-008 |
+| Runtime | `docker info` matches configured log driver, security options (vagrant only) | TEST-008 |
+| Negative path | Security keys absent when features disabled, user NOT in group when disabled | TEST-008 |
+
+### Common test failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `docker package not found` | Package not installed in prepare step | Check `molecule/docker/prepare.yml` installs `docker` (Arch) or `docker.io` (Ubuntu) |
+| Idempotence failure on daemon.json | Template produces different output on second run | Check `set_fact` for non-deterministic values |
+| `python3 -m json.tool` validation fails | daemon.json template error | Run converge, then `docker exec <container> python3 -m json.tool /etc/docker/daemon.json` |
+| Assertion failed: `icc` key absent | `docker_icc` host_var doesn't match expected path | Check `molecule.yml` host_vars match the assertion (nosec vs systemd platform) |
+| Vagrant: `Python not found` | prepare.yml missing or bootstrap skipped | Check `prepare.yml` imports `shared/prepare-vagrant.yml` (TEST-009) |
 
 ## Tags
 
-`docker`, `docker:configure` (daemon.json + group), `docker:service` (enable/start only)
+| Tag | What it runs | Use case |
+|-----|-------------|----------|
+| `docker` | Entire role | Full apply: `ansible-playbook playbook.yml --tags docker` |
+| `docker:configure` | daemon.json deployment + user group | Config-only: `ansible-playbook playbook.yml --tags docker:configure` |
+| `docker:service` | Service enable/start only | Restart Docker without re-deploying config: `ansible-playbook playbook.yml --tags docker:service` |
+| `report` | Logging/report tasks only | Re-generate execution report: `ansible-playbook playbook.yml --tags report` |
 
-Use `--skip-tags service` or set `docker_enable_service: false` to skip service management
-(e.g., in container-based molecule scenarios).
+## File map
 
-## Molecule test coverage
-
-The `docker` scenario tests four platform configurations:
-- `Archlinux-systemd` / `Ubuntu-systemd` — default security settings (all CIS features enabled)
-- `Archlinux-nosec` / `Ubuntu-nosec` — all optional security settings disabled (tests key-absent paths)
-
-## Molecule scenarios
-
-| Scenario | Driver | Scope | Notes |
-|----------|--------|-------|-------|
-| `default` | localhost | Config + service | Runs against real machine, requires vault |
-| `docker` | Docker | Config-only | Uses DinD container, skips service start |
-| `vagrant` | Vagrant (libvirt) | Full | Real VMs with running daemon, Arch + Ubuntu |
-
-## Prerequisites
-
-Docker must be installed before running this role. The role only configures Docker — it does not install the package. Use your distro's package manager or a dedicated installation role before this one.
-
-## Supported platforms
-
-| Platform | Status |
-|----------|--------|
-| Arch Linux | Primary, fully tested |
-| Ubuntu 24.04 | Tested via molecule (docker + vagrant scenarios) |
-| Fedora / RHEL | Supported (distro-agnostic tasks), community tested |
-| Void Linux | Supported (distro-agnostic tasks), community tested |
-| Gentoo | Supported (distro-agnostic tasks), community tested |
+| File | Purpose | Edit? |
+|------|---------|-------|
+| `defaults/main.yml` | All configurable settings and supported OS list | No -- override via inventory |
+| `vars/archlinux.yml` | Service name for Arch Linux | Only when adding Arch-specific overrides |
+| `vars/debian.yml` | Service name for Debian/Ubuntu | Only when adding Debian-specific overrides |
+| `vars/redhat.yml` | Service name for Fedora/RHEL | Only when adding RedHat-specific overrides |
+| `vars/void.yml` | Service name for Void Linux | Only when adding Void-specific overrides |
+| `vars/gentoo.yml` | Service name for Gentoo | Only when adding Gentoo-specific overrides |
+| `templates/daemon.json.j2` | Docker daemon config template | When changing config output format |
+| `tasks/main.yml` | Execution flow orchestrator | When adding/removing steps |
+| `tasks/verify.yml` | Post-deploy self-check | When changing verification logic |
+| `tasks/noop.yml` | Empty task for molecule defaults loading | Never |
+| `handlers/main.yml` | Service restart handler | Rarely |
+| `meta/main.yml` | Galaxy metadata | When changing role metadata |
+| `molecule/` | Test scenarios (docker, vagrant, default) | When changing test coverage |

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -26,6 +26,17 @@
   ansible.builtin.include_vars: "{{ ansible_facts['os_family'] | lower }}.yml"
   tags: ['docker']
 
+- name: "Report: Preflight"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_docker_phases"
+    common_rpt_phase: "Preflight"
+    common_rpt_detail: >-
+      os={{ ansible_facts['os_family'] }}
+  tags: ['docker', 'report']
+
 # ======================================================================
 # ---- Конфигурация daemon ----
 # ======================================================================
@@ -69,6 +80,18 @@
   notify: Restart docker
   tags: ['docker', 'docker:configure']
 
+- name: "Report: Configure daemon"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_docker_phases"
+    common_rpt_phase: "Configure daemon"
+    common_rpt_detail: >-
+      log={{ docker_log_driver }}
+      icc={{ docker_icc }}
+  tags: ['docker', 'report']
+
 # ======================================================================
 # ---- Группа пользователя ----
 # ======================================================================
@@ -88,6 +111,18 @@
   when: docker_add_user_to_group
   tags: ['docker', 'docker:configure']
 
+- name: "Report: User group"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_docker_phases"
+    common_rpt_phase: "User group"
+    common_rpt_status: "{{ 'done' if docker_add_user_to_group else 'skip' }}"
+    common_rpt_detail: >-
+      {{ docker_user | default('n/a') if docker_add_user_to_group else 'disabled' }}
+  tags: ['docker', 'report']
+
 # ======================================================================
 # ---- Сервис ----
 # ======================================================================
@@ -100,6 +135,18 @@
   when: docker_enable_service
   tags: ['docker', 'docker:service']
 
+- name: "Report: Service"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_docker_phases"
+    common_rpt_phase: "Service"
+    common_rpt_status: "{{ 'done' if docker_enable_service else 'skip' }}"
+    common_rpt_detail: >-
+      {{ _docker_service_name if docker_enable_service else 'disabled' }}
+  tags: ['docker', 'report']
+
 # ======================================================================
 # ---- Проверка ----
 # ======================================================================
@@ -107,3 +154,27 @@
 - name: Verify Docker configuration
   ansible.builtin.include_tasks: verify.yml
   tags: ['docker']
+
+- name: "Report: Verify"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_phase.yml
+  vars:
+    common_rpt_fact: "_docker_phases"
+    common_rpt_phase: "Verify"
+    common_rpt_detail: >-
+      daemon.json OK
+  tags: ['docker', 'report']
+
+# ======================================================================
+# ---- Отчёт ----
+# ======================================================================
+
+- name: "Docker — Execution Report"
+  ansible.builtin.include_role:
+    name: common
+    tasks_from: report_render.yml
+  vars:
+    common_rpt_fact: "_docker_phases"
+    common_rpt_title: "docker"
+  tags: ['docker', 'report']


### PR DESCRIPTION
## Summary

- Added ROLE-008 dual logging (`report_phase.yml` for each phase + `report_render.yml` at end) to `tasks/main.yml`
- Rewrote `README.md` to comply with all 10 sections of `readme-requirements.md`: execution flow, variables with safety levels, configuration examples, cross-platform details, logs, troubleshooting, testing, tags, and file map

## Changes

### `tasks/main.yml`
- 5 `report_phase.yml` calls: Preflight, Configure daemon, User group, Service, Verify
- 1 `report_render.yml` call at the end
- All report tasks tagged with `['docker', 'report']`
- Conditional status (`done`/`skip`) for User group and Service phases

### `README.md`
- **README-001**: One-line plain-language header
- **README-002**: Numbered execution flow with handler table
- **README-003**: All 11 variables with safety levels (safe/careful) + internal mappings table
- **README-004**: 4 configuration examples with file paths
- **README-005**: Cross-platform table for all 5 OS families
- **README-006**: Log locations with rotation policy
- **README-007**: 7 troubleshooting entries (symptom/diagnosis/fix)
- **README-008**: Both scenarios, success criteria, verification categories, 5 common failures
- **README-009**: All 4 tags with use cases and commands
- **README-010**: File map with 13 entries and "Edit?" guidance

Closes #93

## Test plan

- [ ] Verify `molecule test -s docker` passes (report tasks are skip-tagged in Docker scenario)
- [ ] Verify `molecule test -s vagrant` passes with execution report output
- [ ] Review README sections against `wiki/standards/readme-requirements.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)