### PR TITLE
fix(packages): resolve role standard violations (post-audit follow-up)

### DIFF
--- a/ansible/roles/packages/README.md
+++ b/ansible/roles/packages/README.md
@@ -10,8 +10,10 @@ Installs workstation packages via OS-native package managers (pacman, apt).
 4. **OS-specific install** (`tasks/install-archlinux.yml` or `tasks/install-debian.yml`)
    - **Arch:** runs `pacman -Syu` (full upgrade, tagged `upgrade`) then installs `packages_all` via `ansible.builtin.package`. Both steps retry up to 3 times on transient mirror failures. Skipped when `packages_all` is empty.
    - **Debian/Ubuntu:** updates apt cache (`cache_valid_time: 3600`) then installs `packages_all` via `ansible.builtin.package`. Install retries up to 3 times. Skipped when `packages_all` is empty.
-5. **Verify** (`tasks/verify.yml`) — gathers `package_facts` and asserts every package in `packages_all` is present; skipped when `packages_all` is empty
-6. **Report** — calls `common/report_phase.yml` and `common/report_render.yml` to emit a structured execution table (skipped via `--skip-tags report` in CI)
+5. **Verify** (`tasks/verify.yml`) — two-technique verification for every package in `packages_all`; skipped when `packages_all` is empty:
+   - **Technique 1 (runtime):** `pacman -Q <pkg>` (Arch) or `dpkg-query -W <pkg>` (Debian) — direct native package manager check
+   - **Technique 2 (state):** `package_facts` + assert — confirms package is in Ansible's fact database
+6. **Report** — calls `common/report_phase.yml` for each phase (verify + install) and `common/report_render.yml` to emit a structured execution table (skipped via `--skip-tags report` in CI)
 
 ### Failure behavior
 
@@ -190,7 +192,12 @@ ansible-playbook site.yml --tags packages --skip-tags upgrade,report
 | `tasks/main.yml` | Execution orchestrator: preflight → build list → install → verify → report | When adding/removing steps |
 | `tasks/install-archlinux.yml` | Arch-specific: system upgrade + package install | When changing Arch install behavior |
 | `tasks/install-debian.yml` | Debian/Ubuntu-specific: cache update + package install | When changing Debian install behavior |
-| `tasks/verify.yml` | In-role post-install verification via package_facts | When changing verification logic |
+| `tasks/verify.yml` | In-role post-install verification: native PM command + package_facts assert | When changing verification logic |
+| `vars/archlinux.yml` | Arch Linux OS-family vars stub (package manager specifics) | When adding Arch-specific variables |
+| `vars/debian.yml` | Debian/Ubuntu OS-family vars stub (package manager specifics) | When adding Debian-specific variables |
+| `vars/redhat.yml` | RedHat/Fedora OS-family vars stub (no install task yet) | When implementing RedHat support |
+| `vars/void.yml` | Void Linux OS-family vars stub (no install task yet) | When implementing Void support |
+| `vars/gentoo.yml` | Gentoo OS-family vars stub (no install task yet) | When implementing Gentoo support |
 | `meta/main.yml` | Role metadata and galaxy info | When updating supported platforms |
 | `molecule/docker/` | Docker CI scenario (Arch + Ubuntu + empty-list edge cases) | When changing CI test coverage |
 | `molecule/vagrant/` | Vagrant cross-platform scenario (Arch VM + Ubuntu VM) | When changing full-system test coverage |

--- a/ansible/roles/packages/molecule/shared/converge.yml
+++ b/ansible/roles/packages/molecule/shared/converge.yml
@@ -5,4 +5,4 @@
   gather_facts: true
 
   roles:
-    - role: packages
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/ansible/roles/packages/molecule/shared/verify.yml
+++ b/ansible/roles/packages/molecule/shared/verify.yml
@@ -1,4 +1,11 @@
 ---
+# Verification categories covered: packages
+# Verification categories skipped:
+#   config files  — role does not write any configuration files
+#   services      — role does not manage any service units
+#   runtime       — role does not start any daemons or network interfaces
+#   permissions   — role does not create files with specific ownership or mode
+
 - name: Verify packages role
   hosts: all
   become: true

--- a/ansible/roles/packages/tasks/install-debian.yml
+++ b/ansible/roles/packages/tasks/install-debian.yml
@@ -6,6 +6,7 @@
   ansible.builtin.apt:
     update_cache: true
     cache_valid_time: 3600
+  tags: ['packages', 'install']
 
 - name: Install packages (apt)
   ansible.builtin.package:

--- a/ansible/roles/packages/tasks/main.yml
+++ b/ansible/roles/packages/tasks/main.yml
@@ -57,6 +57,16 @@
 
     # ---- Report ----
 
+    - name: "Report: Package verification"
+      ansible.builtin.include_role:
+        name: common
+        tasks_from: report_phase.yml
+      vars:
+        common_rpt_fact: "_packages_phases"
+        common_rpt_phase: "Verify packages"
+        common_rpt_detail: "{{ packages_all | length }} pkgs verified on {{ ansible_facts['os_family'] }}"
+      tags: ['packages', 'report']
+
     - name: "Report: Package installation"
       ansible.builtin.include_role:
         name: common

--- a/ansible/roles/packages/tasks/verify.yml
+++ b/ansible/roles/packages/tasks/verify.yml
@@ -2,6 +2,38 @@
 # === In-role verification: check all packages are installed ===
 # Called from tasks/main.yml after installation. Skipped when packages_all is empty.
 
+# Technique 2: runtime check via native package manager
+- name: Verify package installed (pacman -Q)
+  ansible.builtin.command:
+    cmd: "pacman -Q {{ item }}"
+  register: _packages_verify_pacman
+  changed_when: false
+  failed_when: _packages_verify_pacman.rc != 0
+  loop: "{{ packages_all }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - packages_all | length > 0
+    - ansible_facts['os_family'] == 'Archlinux'
+  tags: ['packages']
+
+- name: Verify package installed (dpkg-query)
+  ansible.builtin.command:
+    cmd: "dpkg-query -W -f='${Status}' {{ item }}"
+  register: _packages_verify_dpkg
+  changed_when: false
+  failed_when: >-
+    _packages_verify_dpkg.rc != 0 or
+    'install ok installed' not in _packages_verify_dpkg.stdout
+  loop: "{{ packages_all }}"
+  loop_control:
+    label: "{{ item }}"
+  when:
+    - packages_all | length > 0
+    - ansible_facts['os_family'] == 'Debian'
+  tags: ['packages']
+
+# Technique 3: state assertion via package_facts
 - name: Gather package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/ansible/roles/packages/vars/archlinux.yml
+++ b/ansible/roles/packages/vars/archlinux.yml
@@ -1,0 +1,7 @@
+---
+# Arch Linux — package manager specifics
+# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
+# OS-specific install logic is in tasks/install-archlinux.yml.
+#
+# Arch uses community.general.pacman for the system upgrade step (upgrade: true has no
+# equivalent in ansible.builtin.package) and ansible.builtin.package for installation.

--- a/ansible/roles/packages/vars/debian.yml
+++ b/ansible/roles/packages/vars/debian.yml
@@ -1,0 +1,7 @@
+---
+# Debian/Ubuntu — package manager specifics
+# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
+# OS-specific install logic is in tasks/install-debian.yml.
+#
+# Debian uses ansible.builtin.apt for cache update (cache_valid_time has no equivalent in
+# ansible.builtin.package) and ansible.builtin.package for installation.

--- a/ansible/roles/packages/vars/gentoo.yml
+++ b/ansible/roles/packages/vars/gentoo.yml
@@ -1,0 +1,6 @@
+---
+# Gentoo — package manager specifics
+# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
+#
+# No install task implemented yet (stub). Add tasks/install-gentoo.yml when Gentoo support
+# is required. Package manager: emerge.

--- a/ansible/roles/packages/vars/redhat.yml
+++ b/ansible/roles/packages/vars/redhat.yml
@@ -1,0 +1,6 @@
+---
+# RedHat/Fedora — package manager specifics
+# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
+#
+# No install task implemented yet (stub). Add tasks/install-redhat.yml when RedHat support
+# is required. Package manager: dnf.

--- a/ansible/roles/packages/vars/void.yml
+++ b/ansible/roles/packages/vars/void.yml
@@ -1,0 +1,6 @@
+---
+# Void Linux — package manager specifics
+# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
+#
+# No install task implemented yet (stub). Add tasks/install-void.yml when Void support
+# is required. Package manager: xbps-install.

--- a/wiki/roles/packages.md
+++ b/wiki/roles/packages.md
@@ -63,3 +63,12 @@ Uses `common` role tasks (`report_phase.yml`, `report_render.yml`) for execution
 | `vagrant` | Vagrant/KVM | Arch VM + Ubuntu VM (full list) |
 
 Run: `molecule test -s docker` or `molecule test -s vagrant` from `ansible/roles/packages/`.
+
+## Verification
+
+In-role verify (`tasks/verify.yml`) uses two techniques per package:
+
+1. Native PM command — `pacman -Q <pkg>` (Arch) or `dpkg-query -W <pkg>` (Debian)
+2. `package_facts` assert — confirms presence in Ansible fact database
+
+Molecule verify (`molecule/shared/verify.yml`) mirrors these checks externally.


### PR DESCRIPTION
## Summary

Follow-up to #118 — fixes role standard violations discovered during post-merge audit.

- **ROLE-005**: `tasks/verify.yml` now uses 2 of 3 required verification techniques: native PM command (`pacman -Q` / `dpkg-query`) + `package_facts` assert
- **ROLE-008**: `tasks/main.yml` now calls `report_phase.yml` for verify phase (was only called for install phase)
- **ROLE-001**: Added `vars/` stubs for all 5 OS families (`archlinux`, `debian`, `redhat`, `void`, `gentoo`) per distro-agnostic architecture requirement
- **TEST-006**: Fixed hardcoded `role: packages` in `molecule/shared/converge.yml` — now uses `MOLECULE_PROJECT_DIRECTORY | basename`
- **TEST-008**: Added skipped-categories justification comment to `molecule/shared/verify.yml`
- **Minor**: Added `tags: ['packages', 'install']` to apt cache update task in `install-debian.yml`

## Test plan

- [ ] `molecule test -s docker` passes (Arch + Ubuntu full list + empty-list edge cases)
- [ ] `molecule test -s vagrant` passes (Arch VM + Ubuntu VM)
- [ ] ansible-lint passes with zero errors
- [ ] Idempotence step shows `changed=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)