### PR TITLE
fix(user): address audit FAIL violations

### DIFF
--- a/ansible/roles/user/README.md
+++ b/ansible/roles/user/README.md
@@ -60,6 +60,7 @@ Override via inventory (`group_vars/` or `host_vars/`), never edit `defaults/mai
 | `user_sudo_log_input` | `false` | careful | Record stdin of sudo sessions. Enables forensic logging but may capture passwords |
 | `user_sudo_log_output` | `false` | careful | Record stdout/stderr of sudo sessions. Significant disk usage on busy systems |
 | `user_sudo_passwd_timeout` | `1` | safe | Minutes to enter password at sudo prompt |
+| `user_sudo_config_overwrite` | `{}` | careful | Dict of additional `Defaults` directives merged into the sudoers template. Each key is a directive name, value is the directive value. Overrides or extends the built-in sudo policy without modifying the template. See [Overriding sudo defaults](#overriding-sudo-defaults) |
 | `user_sudo_logrotate_enabled` | `true` | safe | Deploy logrotate config for sudo.log |
 | `user_sudo_logrotate_frequency` | `"weekly"` | safe | Rotation frequency |
 | `user_sudo_logrotate_rotate` | `13` | safe | Number of rotations to keep (~90 days, CIS minimum retention) |
@@ -129,6 +130,18 @@ accounts:
     state: absent
 ```
 
+### Overriding sudo defaults
+
+```yaml
+# In group_vars/all/sudo.yml:
+user_sudo_config_overwrite:
+  env_reset: "true"
+  secure_path: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  mail_badpass: "true"
+```
+
+Each key-value pair renders as `Defaults key=value` in the sudoers file, appended after all built-in directives. Use this to add directives not covered by the dedicated variables (`user_sudo_use_pty`, `user_sudo_logfile`, etc.) without editing the template.
+
 ### Adjusting sudo timeout for a security-focused workstation
 
 ```yaml
@@ -182,7 +195,7 @@ workstation_profiles:
 | `visudo: /etc/sudoers.d/wheel: bad permissions` | File permissions are not 0440 | Role sets 0440 automatically. If changed externally, re-run the role |
 | Password aging not applied | `chage -l <username>` -- check max/min/warn values | Ensure `user_manage_password_aging: true` and values are set in `user_owner` |
 | Root lock assertion fails | `passwd -S root` -- check if root has a password | Lock root: `passwd -l root`. Or set `user_verify_root_lock: false` to skip |
-| Idempotence failure on `chage -W` task | `chage -W` always runs (no state detection) | Expected behavior -- `changed_when: false` suppresses the report since chage has no check mode |
+| `chage -W` shows `changed` on first run | `chage -W` runs only when current warn age differs from desired value | Expected on first apply. Second run (idempotence) shows `ok` because the value already matches |
 | Umask profile not applied after login | `/etc/profile.d/` only runs for login shells | Use `bash -l` or `su - <user>` to trigger profile scripts |
 
 ## Testing

--- a/ansible/roles/user/tasks/additional_users.yml
+++ b/ansible/roles/user/tasks/additional_users.yml
@@ -21,14 +21,41 @@
   when: user_additional_users | length > 0
   tags: [user, cis_5.5.1, cis_5.5.2]
 
-- name: "CIS 5.4.1 | Set password warn age for additional users (chage -W)"
+- name: "CIS 5.4.1 | Read current password warn age for additional users"
   ansible.builtin.command:
-    cmd: "chage -W {{ item.password_warn_age | default(7) }} {{ item.name }}"
+    cmd: "chage -l {{ item.name }}"
+  register: _user_additional_chage_info
   changed_when: false
+  failed_when: _user_additional_chage_info.rc != 0
   loop: "{{ user_additional_users }}"
+  loop_control:
+    label: "{{ item.name }}"
   when:
     - user_manage_password_aging | bool
     - user_additional_users | length > 0
+  tags: [user, cis_5.4.1]
+
+- name: "CIS 5.4.1 | Set password warn age for additional users (chage -W)"
+  ansible.builtin.command:
+    cmd: "chage -W {{ item.0.password_warn_age | default(7) }} {{ item.0.name }}"
+  changed_when: true
+  failed_when: _user_additional_chage_set.rc != 0
+  register: _user_additional_chage_set
+  loop: "{{ user_additional_users | zip(_user_additional_chage_info.results | default([])) | list }}"
+  loop_control:
+    label: "{{ item.0.name }}"
+  when:
+    - user_manage_password_aging | bool
+    - user_additional_users | length > 0
+    - item.1 is not skipped
+    - >-
+      item.1.stdout_lines
+      | select('search', 'warning')
+      | map('regex_replace', '^.*:\s*', '')
+      | map('trim')
+      | first
+      | default('-1')
+      | int != (item.0.password_warn_age | default(7)) | int
   tags: [user, cis_5.4.1]
 
 - name: "Add additional users to sudo group when sudo: true"

--- a/ansible/roles/user/tasks/owner.yml
+++ b/ansible/roles/user/tasks/owner.yml
@@ -19,11 +19,31 @@
   no_log: true
   tags: [user, cis_5.5.1, cis_5.5.2]
 
+- name: "CIS 5.4.1 | Read current password warn age for owner"
+  ansible.builtin.command:
+    cmd: "chage -l {{ user_owner.name }}"
+  register: _user_owner_chage_info
+  changed_when: false
+  failed_when: _user_owner_chage_info.rc != 0
+  when: user_manage_password_aging | bool
+  tags: [user, cis_5.4.1]
+
 - name: "CIS 5.4.1 | Set password warn age for owner (chage -W)"
   ansible.builtin.command:
     cmd: "chage -W {{ user_owner.password_warn_age | default(7) }} {{ user_owner.name }}"
-  changed_when: false
-  when: user_manage_password_aging | bool
+  changed_when: true
+  failed_when: _user_owner_chage_set.rc != 0
+  register: _user_owner_chage_set
+  when:
+    - user_manage_password_aging | bool
+    - >-
+      _user_owner_chage_info.stdout_lines
+      | select('search', 'warning')
+      | map('regex_replace', '^.*:\s*', '')
+      | map('trim')
+      | first
+      | default('-1')
+      | int != (user_owner.password_warn_age | default(7)) | int
   tags: [user, cis_5.4.1]
 
 - name: "CIS 5.4.2 | Deploy umask profile for owner"


### PR DESCRIPTION
## Summary

- **FAIL 1 & 2 (ROLE-013):** Replace `changed_when: false` on `chage -W` commands in `tasks/owner.yml` and `tasks/additional_users.yml` with a read-first idempotency pattern — read current warn age via `chage -l`, then conditionally run `chage -W` only when the value differs
- **FAIL 3 (README-003):** Document `user_sudo_config_overwrite` in README.md Variables table with safety level, description, and usage example
- Update troubleshooting entry to reflect the new idempotent `chage` behavior

## Test plan

- [ ] `molecule test -s docker` passes with `changed=0` on idempotence for `chage -W` tasks
- [ ] `molecule test -s vagrant` passes with password aging verification
- [ ] Verify `user_sudo_config_overwrite` renders correctly in sudoers template

🤖 Generated with [Claude Code](https://claude.com/claude-code)