### PR TITLE
fix(packages): fix report phase order and add requirements.yml

### DIFF
--- a/ansible/roles/packages/requirements.yml
+++ b/ansible/roles/packages/requirements.yml
@@ -1,0 +1,10 @@
+---
+# Role dependencies for packages (TEST-010).
+# The 'common' role is used via include_role for report_phase and report_render.
+#
+# Resolution: molecule provisioner sets ANSIBLE_ROLES_PATH="${MOLECULE_PROJECT_DIRECTORY}/../"
+# so the 'common' role is resolved directly from the source tree — no galaxy install required.
+# The dependency section in molecule.yml uses ignore-errors: true so galaxy does not abort
+# when common is not found on Ansible Galaxy (it is a local monorepo role, not a public role).
+roles:
+  - name: common

--- a/ansible/roles/packages/tasks/main.yml
+++ b/ansible/roles/packages/tasks/main.yml
@@ -57,16 +57,6 @@
 
     # ---- Report ----
 
-    - name: "Report: Package verification"
-      ansible.builtin.include_role:
-        name: common
-        tasks_from: report_phase.yml
-      vars:
-        common_rpt_fact: "_packages_phases"
-        common_rpt_phase: "Verify packages"
-        common_rpt_detail: "{{ packages_all | length }} pkgs verified on {{ ansible_facts['os_family'] }}"
-      tags: ['packages', 'report']
-
     - name: "Report: Package installation"
       ansible.builtin.include_role:
         name: common
@@ -75,6 +65,16 @@
         common_rpt_fact: "_packages_phases"
         common_rpt_phase: "Install packages"
         common_rpt_detail: "{{ packages_all | length }} pkgs on {{ ansible_facts['os_family'] }}"
+      tags: ['packages', 'report']
+
+    - name: "Report: Package verification"
+      ansible.builtin.include_role:
+        name: common
+        tasks_from: report_phase.yml
+      vars:
+        common_rpt_fact: "_packages_phases"
+        common_rpt_phase: "Verify packages"
+        common_rpt_detail: "{{ packages_all | length }} pkgs verified on {{ ansible_facts['os_family'] }}"
       tags: ['packages', 'report']
 
     - name: "Packages -- Execution Report"


### PR DESCRIPTION
## Summary

- **ROLE-008**: Execution report table showed phases in wrong order — "Verify packages" was registered before "Install packages" despite install running first. Swapped order to match execution flow.
- **TEST-010**: Added `requirements.yml` declaring dependency on `common` role, following the monorepo pattern from `sysctl`, `user`, and `gpu_drivers` roles.

## Test plan

- [ ] `molecule test -s docker` passes
- [ ] `molecule test -s vagrant` passes
- [ ] ansible-lint passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)