### PR TITLE
fix(caddy): refactor OS vars to per-file pattern

### DIFF
--- a/ansible/roles/caddy/handlers/main.yml
+++ b/ansible/roles/caddy/handlers/main.yml
@@ -7,6 +7,6 @@
 
 - name: Update CA trust
   ansible.builtin.command:
-    cmd: "{{ _caddy_update_ca_trust_cmd[ansible_facts['os_family']] }}"
+    cmd: "{{ _caddy_update_ca_trust_cmd }}"
   changed_when: true
   listen: Update CA trust

--- a/ansible/roles/caddy/molecule/shared/verify.yml
+++ b/ansible/roles/caddy/molecule/shared/verify.yml
@@ -1,4 +1,8 @@
 ---
+# Verification categories skipped:
+#   packages  -- role deploys via Docker image, no OS packages installed
+#   services  -- service managed via docker compose, not init system
+
 - name: Verify caddy role
   hosts: all
   become: true
@@ -7,10 +11,14 @@
     - ../../defaults/main.yml
     - ../../vars/main.yml
 
+  pre_tasks:
+    - name: Load OS-specific variables for verification
+      ansible.builtin.include_vars: "../../vars/{{ ansible_facts['os_family'] | lower }}.yml"
+
   tasks:
 
     # ===========================================================
-    # Directory structure
+    # Directory structure                              [permissions]
     # ===========================================================
 
     - name: Stat caddy base directory
@@ -28,7 +36,11 @@
           - _caddy_verify_base_dir.stat.mode == '0755'
         fail_msg: >-
           {{ caddy_base_dir }} missing or wrong permissions
-          (expected root:root 0755)
+          (expected root:root 0755, got {{ _caddy_verify_base_dir.stat.pw_name | default('?') }}:{{ _caddy_verify_base_dir.stat.gr_name | default('?') }}
+          {{ _caddy_verify_base_dir.stat.mode | default('?') }})
+        success_msg: >-
+          {{ caddy_base_dir }} exists with correct permissions
+          (root:root {{ _caddy_verify_base_dir.stat.mode }})
 
     - name: Stat caddy subdirectories
       ansible.builtin.stat:
@@ -45,12 +57,13 @@
           - item.stat.exists
           - item.stat.isdir
         fail_msg: "{{ item.item }} directory missing under {{ caddy_base_dir }}"
+        success_msg: "{{ caddy_base_dir }}/{{ item.item }} exists"
       loop: "{{ _caddy_verify_subdirs.results }}"
       loop_control:
         label: "{{ item.item }}"
 
     # ===========================================================
-    # Caddyfile -- existence and permissions
+    # Caddyfile -- existence and permissions        [config files]
     # ===========================================================
 
     - name: Stat Caddyfile
@@ -69,9 +82,13 @@
         fail_msg: >-
           {{ caddy_base_dir }}/Caddyfile missing or wrong permissions
           (expected root:root 0644)
+        success_msg: >-
+          Caddyfile exists with correct permissions
+          ({{ _caddy_verify_caddyfile.stat.pw_name }}:{{ _caddy_verify_caddyfile.stat.gr_name }}
+          {{ _caddy_verify_caddyfile.stat.mode }})
 
     # ===========================================================
-    # Caddyfile -- content assertions
+    # Caddyfile -- content assertions               [config files]
     # ===========================================================
 
     - name: Read Caddyfile
@@ -87,31 +104,36 @@
       ansible.builtin.assert:
         that: "'Ansible' in _caddy_verify_caddyfile_text"
         fail_msg: "Ansible managed marker not found in Caddyfile"
+        success_msg: "Caddyfile contains Ansible managed marker"
 
     - name: Assert Caddyfile contains admin off directive
       ansible.builtin.assert:
         that: "'admin off' in _caddy_verify_caddyfile_text"
         fail_msg: "'admin off' directive missing from Caddyfile"
+        success_msg: "Caddyfile contains 'admin off' directive"
 
     - name: Assert Caddyfile contains local_certs (internal TLS mode)
       ansible.builtin.assert:
         that: "'local_certs' in _caddy_verify_caddyfile_text"
         fail_msg: "'local_certs' directive missing from Caddyfile (expected for tls_mode=internal)"
+        success_msg: "Caddyfile contains 'local_certs' directive (tls_mode=internal)"
       when: caddy_tls_mode == "internal"
 
     - name: Assert Caddyfile does NOT contain local_certs (ACME TLS mode)
       ansible.builtin.assert:
         that: "'local_certs' not in _caddy_verify_caddyfile_text"
         fail_msg: "'local_certs' directive found in Caddyfile but tls_mode is 'acme'"
+        success_msg: "Caddyfile correctly omits 'local_certs' (tls_mode=acme)"
       when: caddy_tls_mode == "acme"
 
     - name: Assert Caddyfile imports sites directory
       ansible.builtin.assert:
         that: "'import /etc/caddy/sites/*.caddy' in _caddy_verify_caddyfile_text"
         fail_msg: "'import /etc/caddy/sites/*.caddy' directive missing from Caddyfile"
+        success_msg: "Caddyfile imports sites directory"
 
     # ===========================================================
-    # docker-compose.yml -- existence and permissions
+    # docker-compose.yml -- existence and permissions [config files]
     # ===========================================================
 
     - name: Stat docker-compose.yml
@@ -130,9 +152,13 @@
         fail_msg: >-
           {{ caddy_base_dir }}/docker-compose.yml missing or wrong permissions
           (expected root:root 0644)
+        success_msg: >-
+          docker-compose.yml exists with correct permissions
+          ({{ _caddy_verify_compose.stat.pw_name }}:{{ _caddy_verify_compose.stat.gr_name }}
+          {{ _caddy_verify_compose.stat.mode }})
 
     # ===========================================================
-    # docker-compose.yml -- content assertions
+    # docker-compose.yml -- content assertions       [config files]
     # ===========================================================
 
     - name: Read docker-compose.yml
@@ -148,39 +174,46 @@
       ansible.builtin.assert:
         that: "'Ansible' in _caddy_verify_compose_text"
         fail_msg: "Ansible managed marker not found in docker-compose.yml"
+        success_msg: "docker-compose.yml contains Ansible managed marker"
 
     - name: Assert docker-compose.yml uses correct image
       ansible.builtin.assert:
         that: "'{{ caddy_docker_image }}' in _caddy_verify_compose_text"
         fail_msg: "{{ caddy_docker_image }} image not found in docker-compose.yml"
+        success_msg: "docker-compose.yml uses image {{ caddy_docker_image }}"
 
     - name: Assert docker-compose.yml maps HTTPS port
       ansible.builtin.assert:
         that: "'{{ caddy_https_port | string }}:443' in _caddy_verify_compose_text"
         fail_msg: "HTTPS port mapping {{ caddy_https_port }}:443 not found in docker-compose.yml"
+        success_msg: "docker-compose.yml maps HTTPS port {{ caddy_https_port }}:443"
 
     - name: Assert docker-compose.yml maps HTTP port
       ansible.builtin.assert:
         that: "'{{ caddy_http_port | string }}:80' in _caddy_verify_compose_text"
         fail_msg: "HTTP port mapping {{ caddy_http_port }}:80 not found in docker-compose.yml"
+        success_msg: "docker-compose.yml maps HTTP port {{ caddy_http_port }}:80"
 
     - name: Assert docker-compose.yml mounts Caddyfile
       ansible.builtin.assert:
         that: "'{{ caddy_base_dir }}/Caddyfile:/etc/caddy/Caddyfile:ro' in _caddy_verify_compose_text"
         fail_msg: "Caddyfile volume mount not found in docker-compose.yml"
+        success_msg: "docker-compose.yml mounts Caddyfile"
 
     - name: Assert docker-compose.yml mounts sites directory
       ansible.builtin.assert:
         that: "'{{ caddy_base_dir }}/sites:/etc/caddy/sites:ro' in _caddy_verify_compose_text"
         fail_msg: "Sites volume mount not found in docker-compose.yml"
+        success_msg: "docker-compose.yml mounts sites directory"
 
     - name: Assert docker-compose.yml references proxy network
       ansible.builtin.assert:
         that: "'{{ caddy_docker_network }}' in _caddy_verify_compose_text"
         fail_msg: "Docker network '{{ caddy_docker_network }}' not found in docker-compose.yml"
+        success_msg: "docker-compose.yml references proxy network '{{ caddy_docker_network }}'"
 
     # ===========================================================
-    # Docker network and container (requires Docker daemon)
+    # Docker network and container (requires Docker daemon) [runtime]
     # ===========================================================
 
     - name: Check Docker daemon is running  # noqa: command-instead-of-module
@@ -205,6 +238,7 @@
             fail_msg: >-
               Docker network '{{ caddy_docker_network }}' does not exist.
               Expected the caddy role to create it.
+            success_msg: "Docker network '{{ caddy_docker_network }}' exists"
 
         - name: Check caddy container is running  # noqa: command-instead-of-module
           ansible.builtin.command: >
@@ -221,6 +255,7 @@
             fail_msg: >-
               Caddy container is not running.
               Status: {{ _caddy_verify_container_status.stdout | default('container not found') }}
+            success_msg: "Caddy container is running (status={{ _caddy_verify_container_status.stdout }})"
 
         - name: Validate Caddyfile syntax inside container  # noqa: command-instead-of-module
           ansible.builtin.command: docker exec caddy caddy validate --config /etc/caddy/Caddyfile
@@ -234,6 +269,7 @@
             fail_msg: >-
               Caddyfile validation failed inside container:
               {{ _caddy_verify_validate.stderr | default('') }}
+            success_msg: "Caddyfile syntax validation passed inside container"
 
         - name: Check caddy container is connected to proxy network  # noqa: command-instead-of-module
           ansible.builtin.command: >
@@ -248,6 +284,7 @@
             fail_msg: >-
               Caddy container is not connected to '{{ caddy_docker_network }}' network.
               Networks: {{ _caddy_verify_container_networks.stdout | default('') }}
+            success_msg: "Caddy container is connected to '{{ caddy_docker_network }}' network"
 
     - name: Warn if Docker daemon not available (config-only verification)
       ansible.builtin.debug:
@@ -258,7 +295,7 @@
       when: _caddy_verify_docker_info.rc != 0
 
     # ===========================================================
-    # CA trust (internal TLS only, requires Docker daemon)
+    # CA trust (internal TLS only, requires Docker daemon) [permissions]
     # ===========================================================
 
     - name: Verify CA trust deployment
@@ -270,7 +307,7 @@
 
         - name: Stat Caddy root CA in system trust store
           ansible.builtin.stat:
-            path: "{{ _caddy_ca_trust_dir[ansible_facts['os_family']] }}/{{ _caddy_ca_cert_filename }}"
+            path: "{{ _caddy_ca_trust_dir }}/{{ _caddy_ca_cert_filename }}"
           register: _caddy_verify_ca_cert
 
         - name: Assert Caddy root CA exists in trust store
@@ -280,8 +317,11 @@
               - _caddy_verify_ca_cert.stat.mode == '0644'
             fail_msg: >-
               Caddy root CA not found at
-              {{ _caddy_ca_trust_dir[ansible_facts['os_family']] }}/{{ _caddy_ca_cert_filename }}
+              {{ _caddy_ca_trust_dir }}/{{ _caddy_ca_cert_filename }}
               or has wrong permissions
+            success_msg: >-
+              Caddy root CA exists at {{ _caddy_ca_trust_dir }}/{{ _caddy_ca_cert_filename }}
+              (mode={{ _caddy_verify_ca_cert.stat.mode }})
 
     # ===========================================================
     # Summary

--- a/ansible/roles/caddy/tasks/main.yml
+++ b/ansible/roles/caddy/tasks/main.yml
@@ -17,6 +17,14 @@
       tags: ['caddy']
 
     # ======================================================================
+    # ---- OS-specific vars ----
+    # ======================================================================
+
+    - name: Load OS-specific variables
+      ansible.builtin.include_vars: "{{ ansible_facts['os_family'] | lower }}.yml"
+      tags: ['caddy']
+
+    # ======================================================================
     # ---- Docker network ----
     # ======================================================================
 
@@ -103,7 +111,7 @@
         - name: Deploy Caddy root CA to trust store
           ansible.builtin.copy:
             content: "{{ _caddy_ca_new.content | b64decode }}"
-            dest: "{{ _caddy_ca_trust_dir[ansible_facts['os_family']] }}/{{ _caddy_ca_cert_filename }}"
+            dest: "{{ _caddy_ca_trust_dir }}/{{ _caddy_ca_cert_filename }}"
             owner: root
             group: root
             mode: '0644'
@@ -128,7 +136,7 @@
 
         - name: Check if Zen Browser is installed
           ansible.builtin.stat:
-            path: "{{ _caddy_browser_policy_dir[ansible_facts['os_family']] | dirname }}"
+            path: "{{ _caddy_browser_policy_dir | dirname }}"
           register: _caddy_zen_check
 
         - name: Deploy Zen Browser enterprise root policy
@@ -137,7 +145,7 @@
 
             - name: Create Zen Browser distribution directory
               ansible.builtin.file:
-                path: "{{ _caddy_browser_policy_dir[ansible_facts['os_family']] }}"
+                path: "{{ _caddy_browser_policy_dir }}"
                 state: directory
                 owner: root
                 group: root
@@ -145,7 +153,7 @@
 
             - name: Configure Zen Browser to trust system CA
               ansible.builtin.copy:
-                dest: "{{ _caddy_browser_policy_dir[ansible_facts['os_family']] }}/policies.json"
+                dest: "{{ _caddy_browser_policy_dir }}/policies.json"
                 content: '{"policies":{"Certificates":{"ImportEnterpriseRoots":true}}}'
                 owner: root
                 group: root
@@ -154,7 +162,7 @@
         - name: Report Zen Browser not installed (skipping browser trust)
           ansible.builtin.debug:
             msg: >-
-              Zen Browser not found at {{ _caddy_browser_policy_dir[ansible_facts['os_family']] | dirname }}.
+              Zen Browser not found at {{ _caddy_browser_policy_dir | dirname }}.
               Skipping browser enterprise root trust configuration.
           when: not _caddy_zen_check.stat.exists
 

--- a/ansible/roles/caddy/vars/archlinux.yml
+++ b/ansible/roles/caddy/vars/archlinux.yml
@@ -1,0 +1,11 @@
+---
+# OS-specific variables for Arch Linux
+
+# CA trust store anchor directory
+_caddy_ca_trust_dir: /etc/ca-certificates/trust-source/anchors
+
+# Command to update system CA trust
+_caddy_update_ca_trust_cmd: update-ca-trust
+
+# Browser distribution directory for enterprise root policy
+_caddy_browser_policy_dir: /usr/lib/zen-browser/distribution

--- a/ansible/roles/caddy/vars/debian.yml
+++ b/ansible/roles/caddy/vars/debian.yml
@@ -1,0 +1,11 @@
+---
+# OS-specific variables for Debian/Ubuntu
+
+# CA trust store anchor directory
+_caddy_ca_trust_dir: /usr/local/share/ca-certificates
+
+# Command to update system CA trust
+_caddy_update_ca_trust_cmd: update-ca-certificates
+
+# Browser distribution directory for enterprise root policy
+_caddy_browser_policy_dir: /usr/lib/zen-browser/distribution

--- a/ansible/roles/caddy/vars/gentoo.yml
+++ b/ansible/roles/caddy/vars/gentoo.yml
@@ -1,0 +1,11 @@
+---
+# OS-specific variables for Gentoo
+
+# CA trust store anchor directory
+_caddy_ca_trust_dir: /usr/local/share/ca-certificates
+
+# Command to update system CA trust
+_caddy_update_ca_trust_cmd: update-ca-certificates
+
+# Browser distribution directory for enterprise root policy
+_caddy_browser_policy_dir: /usr/lib/zen-browser/distribution

--- a/ansible/roles/caddy/vars/main.yml
+++ b/ansible/roles/caddy/vars/main.yml
@@ -1,31 +1,5 @@
 ---
-# === Caddy — internal OS mappings ===
-
-# CA trust store anchor directory per OS family
-# Where to copy Caddy root CA for system-wide trust
-_caddy_ca_trust_dir:
-  Archlinux: /etc/ca-certificates/trust-source/anchors
-  Debian: /usr/local/share/ca-certificates
-  RedHat: /etc/pki/ca-trust/source/anchors
-  Gentoo: /usr/local/share/ca-certificates
-  Void: /etc/ssl/certs
-
-# Command to update system CA trust after adding a certificate
-_caddy_update_ca_trust_cmd:
-  Archlinux: update-ca-trust
-  Debian: update-ca-certificates
-  RedHat: update-ca-trust
-  Gentoo: update-ca-certificates
-  Void: update-ca-certificates
+# === Caddy -- common internal variables ===
 
 # CA cert filename placed in trust store
 _caddy_ca_cert_filename: "caddy-local.crt"
-
-# Browser distribution directory for enterprise root policy
-# Zen Browser follows Firefox directory structure
-_caddy_browser_policy_dir:
-  Archlinux: /usr/lib/zen-browser/distribution
-  Debian: /usr/lib/zen-browser/distribution
-  RedHat: /usr/lib64/zen-browser/distribution
-  Gentoo: /usr/lib/zen-browser/distribution
-  Void: /usr/lib/zen-browser/distribution

--- a/ansible/roles/caddy/vars/redhat.yml
+++ b/ansible/roles/caddy/vars/redhat.yml
@@ -1,0 +1,11 @@
+---
+# OS-specific variables for Fedora/RedHat
+
+# CA trust store anchor directory
+_caddy_ca_trust_dir: /etc/pki/ca-trust/source/anchors
+
+# Command to update system CA trust
+_caddy_update_ca_trust_cmd: update-ca-trust
+
+# Browser distribution directory for enterprise root policy
+_caddy_browser_policy_dir: /usr/lib64/zen-browser/distribution

--- a/ansible/roles/caddy/vars/void.yml
+++ b/ansible/roles/caddy/vars/void.yml
@@ -1,0 +1,11 @@
+---
+# OS-specific variables for Void Linux
+
+# CA trust store anchor directory
+_caddy_ca_trust_dir: /etc/ssl/certs
+
+# Command to update system CA trust
+_caddy_update_ca_trust_cmd: update-ca-certificates
+
+# Browser distribution directory for enterprise root policy
+_caddy_browser_policy_dir: /usr/lib/zen-browser/distribution


### PR DESCRIPTION
## Summary

- Split OS-specific variables (`_caddy_ca_trust_dir`, `_caddy_update_ca_trust_cmd`, `_caddy_browser_policy_dir`) from `vars/main.yml` into per-OS files (`vars/archlinux.yml`, `vars/debian.yml`, `vars/gentoo.yml`, `vars/redhat.yml`, `vars/void.yml`)
- Add `include_vars` task in `tasks/main.yml` to load the correct OS-specific file at runtime
- Fix handler `Update CA trust` to use flat `_caddy_update_ca_trust_cmd` instead of `_caddy_update_ca_trust_cmd[ansible_facts['os_family']]` dict lookup (fixes remaining var-naming violation)
- Fix `tasks/main.yml` and `molecule/shared/verify.yml` to use flat vars loaded from per-OS file
- Improve verify.yml assertions with `success_msg` and richer `fail_msg` containing actual vs expected values

## Motivation

After PR #266 was merged, there were remaining `var-naming` violations and inconsistencies:
- Handler still used `_caddy_update_ca_trust_cmd[ansible_facts['os_family']]` dict syntax
- `vars/main.yml` still had OS-keyed dicts instead of the per-file pattern used by other roles (teleport, ssh, etc.)

This PR makes caddy consistent with the project's established per-OS vars pattern.

## Test plan

- [ ] `molecule test -s docker` passes (config-only verification, no Docker-in-Docker)
- [ ] `molecule test -s vagrant` passes (full runtime verification with Docker)
- [ ] ansible-lint reports no violations on caddy role

🤖 Generated with [Claude Code](https://claude.com/claude-code)