### PR TITLE
fix(docker): address role audit findings

### DIFF
--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -7,9 +7,9 @@ Configures Docker daemon with CIS-hardened defaults (daemon.json, service manage
 1. **Preflight** (`tasks/main.yml`) -- asserts OS family is in the supported list (`Archlinux`, `Debian`, `RedHat`, `Void`, `Gentoo`); fails immediately if unsupported
 2. **Load OS variables** (`vars/<os_family>.yml`) -- loads distro-specific service name (`_docker_service_name`)
 3. **Create config directory** -- ensures `/etc/docker/` exists with `root:root 0755`
-4. **Build daemon config** -- assembles `docker_daemon_config` dict via `set_fact`, conditionally merging security settings (`userns-remap`, `icc`, `live-restore`, `no-new-privileges`) and storage driver
+4. **Build daemon config** -- merges logging, storage, and security settings into a single dict; applies `docker_daemon_overwrite` on top
 5. **Deploy daemon.json** -- renders `/etc/docker/daemon.json` from Jinja2 template with JSON validation (`python3 -m json.tool`). **Triggers handler:** if config changed, Docker will be restarted.
-6. **User group** -- ensures `docker` group exists and adds `docker_user` to it (skipped when `docker_add_user_to_group: false`)
+6. **User group** -- ensures `docker` group exists, validates target user exists, adds `docker_user` to it (skipped when `docker_add_user_to_group: false`)
 7. **Service** -- enables and starts Docker service (skipped when `docker_enable_service: false`)
 8. **Verify** (`tasks/verify.yml`) -- checks `/etc/docker/` permissions, `daemon.json` validity (JSON parse), correct ownership and mode
 9. **Report** -- writes execution report via `common/report_phase` + `report_render`
@@ -39,6 +39,16 @@ Override these via inventory (`group_vars/` or `host_vars/`), never edit `defaul
 | `docker_icc` | `false` | careful | Inter-container communication via `docker0` bridge. `false` = containers must use user-defined networks (Docker Compose creates them automatically) |
 | `docker_live_restore` | `true` | safe | Keep containers running when dockerd restarts. Incompatible with Docker Swarm |
 | `docker_no_new_privileges` | `true` | safe | Block setuid privilege escalation in containers. Per-container override: `--security-opt no-new-privileges=false` |
+| `docker_daemon_overwrite` | `{}` | internal | Dict merged on top of computed daemon.json. Use for any settings not covered by dedicated variables |
+
+### CIS Docker Benchmark defaults
+
+| Setting | Value | CIS Control | Effect |
+|---------|-------|-------------|--------|
+| `userns-remap` | `"default"` | CIS 2.8 | Isolates container UIDs from host UIDs |
+| `icc` | `false` | CIS 2.1 | Disables direct inter-container communication on docker0 |
+| `live-restore` | `true` | CIS 2.14 | Daemon resilience without stopping containers |
+| `no-new-privileges` | `true` | CIS 5.25 | Prevents privilege escalation via setuid |
 
 ### Internal mappings (`vars/`)
 
@@ -75,6 +85,21 @@ docker_icc: true                 # allow inter-container communication
 docker_no_new_privileges: false  # allow setuid in containers
 ```
 
+### Adding custom daemon.json settings
+
+```yaml
+# In host_vars/<hostname>/docker.yml:
+docker_daemon_overwrite:
+  dns:
+    - "8.8.8.8"
+    - "8.8.4.4"
+  default-address-pools:
+    - base: "172.80.0.0/16"
+      size: 24
+```
+
+Values in `docker_daemon_overwrite` are merged recursively on top of all computed settings.
+
 ### Skipping user group membership
 
 ```yaml
@@ -95,42 +120,42 @@ Or use tags: `ansible-playbook playbook.yml --tags docker:configure`
 
 ## Cross-platform details
 
-| Aspect | Arch Linux | Ubuntu / Debian | Fedora / RHEL | Void Linux | Gentoo |
-|--------|-----------|-----------------|---------------|------------|--------|
+| Aspect | Arch Linux | Ubuntu / Debian | Fedora / RedHat | Void Linux | Gentoo |
+|--------|-----------|-----------------|-----------------|------------|--------|
 | Service name | `docker` | `docker` | `docker` | `docker` | `docker` |
-| Package name | `docker` | `docker.io` | `docker` | `docker` | `app-containers/docker` |
 | Config path | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` | `/etc/docker/daemon.json` |
+| Package | `docker` | `docker.io` / `docker-ce` | `docker-ce` | `docker` | `app-containers/docker` |
 
-The config path is identical across all distros. Package names differ -- this role does not install Docker, so the package name is only relevant to the prepare step in molecule tests.
+Docker service name is consistent across all distros. Config path is always `/etc/docker/daemon.json`. Package installation is handled outside this role.
 
 ## Logs
 
 ### Log files
 
-| File | Path | Contents | Rotation |
-|------|------|----------|----------|
+| Source | Path | Contents | Rotation |
+|--------|------|----------|----------|
+| Docker daemon | `journalctl -u docker` | Daemon start/stop, config reload, container lifecycle | System journal rotation |
 | Container logs (journald) | `journalctl CONTAINER_NAME=<name>` | Container stdout/stderr | System journal rotation |
-| Container logs (json-file) | `/var/lib/docker/containers/<id>/<id>-json.log` | Container stdout/stderr as JSON | `docker_log_max_size` / `docker_log_max_file` |
-| Docker daemon | `journalctl -u docker` | Daemon start/stop, errors, warnings | System journal rotation |
-| daemon.json | `/etc/docker/daemon.json` | Not a log -- config file deployed by this role | N/A |
+| Container logs (json-file) | `/var/lib/docker/containers/<id>/<id>-json.log` | Container stdout/stderr | `docker_log_max_size` / `docker_log_max_file` |
+| daemon.json | `/etc/docker/daemon.json` | Static config file (not a log) | N/A -- managed by this role |
 
 ### Reading the logs
 
-- Daemon issues: `journalctl -u docker -n 50 --no-pager`
+- Daemon errors: `journalctl -u docker -n 50 --no-pager`
 - Container logs: `docker logs <container>` or `journalctl CONTAINER_NAME=<name>`
-- Live-restore events: `journalctl -u docker | grep live-restore`
+- Config validation: `python3 -m json.tool /etc/docker/daemon.json`
 
 ## Troubleshooting
 
 | Symptom | Diagnosis | Fix |
 |---------|-----------|-----|
-| Role fails at "Assert supported operating system" | OS family not in supported list | Check `ansible_facts['os_family']` -- must be one of: Archlinux, Debian, RedHat, Void, Gentoo |
-| `daemon.json` validation fails | Invalid JSON syntax in merged config | Run `python3 -m json.tool /etc/docker/daemon.json` to see the error. Check variable values for unquoted strings |
-| Docker won't start after config change | Bad daemon.json or conflicting settings | `journalctl -u docker -n 50`. Common: `userns-remap` with incompatible storage driver |
-| Containers can't talk to each other | `docker_icc: false` blocks `docker0` traffic | Use user-defined networks (`docker network create mynet`) or set `docker_icc: true` |
-| Bind-mount permission denied | `userns-remap` shifts UIDs by 100000 | Use named volumes, or `chown 100000:100000` on host directories, or disable `docker_userns_remap: ""` |
-| User can't run `docker` commands | Not in docker group, or session not refreshed | Check: `id -nG <user>`. If `docker` missing: verify `docker_add_user_to_group: true`. Log out and back in for group changes to take effect |
-| Handler didn't restart Docker | `docker_enable_service: false` skips handler | Set `docker_enable_service: true` or restart manually: `systemctl restart docker` |
+| Role fails at "Assert supported operating system" | OS family not in supported list | Check `ansible_facts['os_family']` matches one of: Archlinux, Debian, RedHat, Void, Gentoo |
+| Role fails at "Assert target user exists" | `docker_user` resolves to a non-existent user | Set `docker_user` to a valid username or ensure the user is created before this role |
+| daemon.json validation fails | Invalid JSON in template output | Check `docker_daemon_overwrite` for syntax errors. Run: `python3 -m json.tool /etc/docker/daemon.json` |
+| Docker won't start after config change | Invalid daemon.json options | `journalctl -u docker -n 50` for error. Common: storage-driver mismatch with existing data |
+| userns-remap breaks volume permissions | Container UID remapped to 100000+ range | Use named volumes, or `chown 100000:100000 /path/to/bind/mount` on host |
+| Containers can't communicate | `docker_icc: false` blocks docker0 bridge traffic | Use user-defined networks (`docker network create`) or Docker Compose networks (created automatically) |
+| Handler doesn't restart Docker | `docker_enable_service: false` prevents restart | Set `docker_enable_service: true` or restart manually: `systemctl restart docker` |
 
 ## Testing
 
@@ -138,8 +163,8 @@ Both scenarios are required for every role (TEST-002). Run Docker for fast feedb
 
 | Scenario | Command | When to use | What it tests |
 |----------|---------|-------------|---------------|
-| Docker (fast) | `molecule test -s docker` | After changing variables, templates, or task logic | Config deployment, idempotence, daemon.json content, negative-path assertions |
-| Vagrant (cross-platform) | `molecule test -s vagrant` | After changing OS-specific logic, services, or security settings | Real systemd, real packages, Arch + Ubuntu matrix, service state, runtime `docker info` |
+| Docker (fast) | `molecule test -s docker` | After changing variables, templates, or task logic | Config deployment, JSON validation, idempotence, security key presence/absence |
+| Vagrant (cross-platform) | `molecule test -s vagrant` | After changing OS-specific logic or service tasks | Real systemd, real packages, Arch + Ubuntu matrix, service start |
 
 ### Success criteria
 
@@ -152,23 +177,23 @@ Both scenarios are required for every role (TEST-002). Run Docker for fast feedb
 
 | Category | Examples | Test requirement |
 |----------|----------|-----------------|
-| Directory | `/etc/docker/` exists with `root:root 0755` | TEST-008 |
-| Config file | `daemon.json` exists with `root:root 0644`, valid JSON | TEST-008 |
-| Config content | `log-driver`, `log-opts`, security keys match variables | TEST-008 |
-| Group | `docker` group exists, user is member | TEST-008 |
-| Service | `docker.service` enabled + running (vagrant only) | TEST-008 |
-| Runtime | `docker info` matches configured log driver, security options (vagrant only) | TEST-008 |
-| Negative path | Security keys absent when features disabled, user NOT in group when disabled | TEST-008 |
+| Directories | `/etc/docker/` exists with root:root 0755 | TEST-008 |
+| Config files | `daemon.json` exists, valid JSON, correct permissions | TEST-008 |
+| Config content | log-driver, security keys match variables | TEST-008 |
+| Negative paths | Security keys absent when features disabled | TEST-008 |
+| User group | docker group exists, user membership | TEST-008 |
+| Services | docker.service running + enabled (vagrant only) | TEST-008 |
+| Runtime | `docker info` matches configured settings (vagrant only) | TEST-008 |
 
 ### Common test failures
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `docker package not found` | Package not installed in prepare step | Check `molecule/docker/prepare.yml` installs `docker` (Arch) or `docker.io` (Ubuntu) |
-| Idempotence failure on daemon.json | Template produces different output on second run | Check `set_fact` for non-deterministic values |
-| `python3 -m json.tool` validation fails | daemon.json template error | Run converge, then `docker exec <container> python3 -m json.tool /etc/docker/daemon.json` |
-| Assertion failed: `icc` key absent | `docker_icc` host_var doesn't match expected path | Check `molecule.yml` host_vars match the assertion (nosec vs systemd platform) |
-| Vagrant: `Python not found` | prepare.yml missing or bootstrap skipped | Check `prepare.yml` imports `shared/prepare-vagrant.yml` (TEST-009) |
+| `daemon.json missing or wrong permissions` | Converge didn't run or failed silently | Run full sequence: `molecule test -s docker`, not just converge |
+| `JSON validation failed` | Template produces invalid JSON | Check `docker_daemon_overwrite` for trailing commas or unquoted keys |
+| Idempotence failure on daemon.json | `set_fact` produces different dict ordering | Usually harmless -- Ansible dict ordering varies. Check for actual content changes |
+| `docker.service is not enabled` (vagrant) | Docker not installed in prepare step | Check `molecule/vagrant/prepare.yml` installs Docker |
+| `User not in docker group` | User doesn't exist in container | Set `docker_add_user_to_group: false` in container host_vars |
 
 ## Tags
 
@@ -177,7 +202,19 @@ Both scenarios are required for every role (TEST-002). Run Docker for fast feedb
 | `docker` | Entire role | Full apply: `ansible-playbook playbook.yml --tags docker` |
 | `docker:configure` | daemon.json deployment + user group | Config-only: `ansible-playbook playbook.yml --tags docker:configure` |
 | `docker:service` | Service enable/start only | Restart Docker without re-deploying config: `ansible-playbook playbook.yml --tags docker:service` |
+| `security` | Security-tagged tasks (daemon.json deploy) | Audit security configuration |
 | `report` | Logging/report tasks only | Re-generate execution report: `ansible-playbook playbook.yml --tags report` |
+
+```bash
+# Full role apply
+ansible-playbook playbook.yml --tags docker
+
+# Config only, no service management
+ansible-playbook playbook.yml --tags docker:configure
+
+# Service management only
+ansible-playbook playbook.yml --tags docker:service
+```
 
 ## File map
 
@@ -195,4 +232,7 @@ Both scenarios are required for every role (TEST-002). Run Docker for fast feedb
 | `tasks/noop.yml` | Empty task for molecule defaults loading | Never |
 | `handlers/main.yml` | Service restart handler | Rarely |
 | `meta/main.yml` | Galaxy metadata | When changing role metadata |
-| `molecule/` | Test scenarios (docker, vagrant, default) | When changing test coverage |
+| `molecule/shared/` | Shared converge and verify playbooks | When changing test assertions |
+| `molecule/docker/` | Docker-based test scenario | When changing container test config |
+| `molecule/vagrant/` | Vagrant-based test scenario | When changing VM test config |
+| `molecule/default/` | Localhost test scenario | When changing local test config |

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -18,23 +18,34 @@ docker_manage_daemon: true
 docker_add_user_to_group: true
 docker_enable_service: true
 
+# ---- Core settings (safe) ----
+
 # Целевой пользователь (добавляется в группу docker)
+# Safety: safe — user must exist on the system
 docker_user: "{{ ansible_facts['env']['SUDO_USER'] | default(ansible_facts['user_id']) }}"
 
-# --- Daemon configuration (ROLE-010) ---
-# Dict-based config merged with docker_daemon_overwrite in template
-docker_daemon_config:
-  log-driver: "journald"
-  log-opts:
-    max-size: "10m"
-    max-file: "3"
+# ---- Logging (safe) ----
 
-# User overrides merged on top of docker_daemon_config (ROLE-010)
-# Example: docker_daemon_overwrite: { "default-runtime": "nvidia" }
-docker_daemon_overwrite: {}
+# Logging driver for containers
+# Safety: safe — journald integrates with systemd journal
+docker_log_driver: "journald"
 
-# --- CIS Docker Benchmark security settings (ROLE-004) ---
-# Each setting has a CIS control ID and individual toggle for granular control
+# Max log file size (applies to non-journald drivers)
+# Safety: safe
+docker_log_max_size: "10m"
+
+# Max number of rotated log files (applies to non-journald drivers)
+# Safety: safe
+docker_log_max_file: "3"
+
+# ---- Storage (careful) ----
+
+# Storage driver — empty uses Docker default (overlay2 on modern kernels)
+# Safety: careful — changing on existing install requires data migration
+docker_storage_driver: ""
+
+# ---- Security features (careful) ----
+# CIS Docker Benchmark defaults
 
 # CIS 2.8 — Enable user namespace support (userns-remap)
 # WARNING: userns-remap ломает volume permissions — используйте named volumes
@@ -60,5 +71,9 @@ docker_live_restore: true
 # При необходимости — per-container override: --security-opt no-new-privileges=false
 docker_no_new_privileges: true
 
-# Storage driver (empty = Docker auto-selects; set e.g. "overlay2" to force)
-docker_storage_driver: ""
+# ---- Customization (internal) ----
+
+# User-provided daemon.json overrides — merged on top of computed config
+# Safety: internal — values here override all computed settings
+# Example: { "dns": ["8.8.8.8"], "default-address-pools": [{"base": "172.80.0.0/16", "size": 24}] }
+docker_daemon_overwrite: {}

--- a/ansible/roles/docker/meta/main.yml
+++ b/ansible/roles/docker/meta/main.yml
@@ -11,4 +11,5 @@ galaxy_info:
     - name: Ubuntu
       versions: [all]
   galaxy_tags: [docker, container, service]
-dependencies: []
+dependencies:
+  - role: common

--- a/ansible/roles/docker/molecule/docker/molecule.yml
+++ b/ansible/roles/docker/molecule/docker/molecule.yml
@@ -56,11 +56,9 @@ provisioner:
     group_vars:
       all:
         # Role defaults for verify.yml assertions (group_vars precedence < host_vars)
-        docker_daemon_config:
-          log-driver: "journald"
-          log-opts:
-            max-size: "10m"
-            max-file: "3"
+        docker_log_driver: "journald"
+        docker_log_max_size: "10m"
+        docker_log_max_file: "3"
         docker_daemon_overwrite: {}
         docker_storage_driver: ""
         docker_userns_remap: "default"
@@ -71,7 +69,6 @@ provisioner:
         docker_enable_service: true
         docker_manage_daemon: true
         docker_user: "root"
-        docker_daemon_overwrite: {}
     host_vars:
       # Default security settings (all CIS features enabled)
       # docker_add_user_to_group=false to avoid usermod in containers (unstable in DinD)

--- a/ansible/roles/docker/molecule/docker/molecule.yml
+++ b/ansible/roles/docker/molecule/docker/molecule.yml
@@ -71,6 +71,7 @@ provisioner:
         docker_enable_service: true
         docker_manage_daemon: true
         docker_user: "root"
+        docker_daemon_overwrite: {}
     host_vars:
       # Default security settings (all CIS features enabled)
       # docker_add_user_to_group=false to avoid usermod in containers (unstable in DinD)

--- a/ansible/roles/docker/molecule/shared/verify.yml
+++ b/ansible/roles/docker/molecule/shared/verify.yml
@@ -84,32 +84,32 @@
       ansible.builtin.assert:
         that:
           - "'log-driver' in _docker_verify_daemon_dict"
-          - "_docker_verify_daemon_dict['log-driver'] == docker_daemon_config['log-driver']"
+          - "_docker_verify_daemon_dict['log-driver'] == docker_log_driver"
         fail_msg: >-
-          log-driver not set to '{{ docker_daemon_config['log-driver'] | default('') }}' in daemon.json
+          log-driver not set to '{{ docker_log_driver | default('') }}' in daemon.json
         success_msg: >-
-          log-driver={{ _docker_verify_daemon_dict['log-driver'] }} (expected {{ docker_daemon_config['log-driver'] }})
+          log-driver={{ _docker_verify_daemon_dict['log-driver'] }} (expected {{ docker_log_driver }})
 
     - name: Assert log-opts max-size matches variable
       ansible.builtin.assert:
         that:
           - "'log-opts' in _docker_verify_daemon_dict"
-          - "_docker_verify_daemon_dict['log-opts']['max-size'] == docker_daemon_config['log-opts']['max-size']"
+          - "_docker_verify_daemon_dict['log-opts']['max-size'] == docker_log_max_size"
         fail_msg: >-
-          log-opts.max-size not set to '{{ docker_daemon_config['log-opts']['max-size'] | default('') }}' in daemon.json
+          log-opts.max-size not set to '{{ docker_log_max_size | default('') }}' in daemon.json
         success_msg: >-
           log-opts.max-size={{ _docker_verify_daemon_dict['log-opts']['max-size'] }}
-          (expected {{ docker_daemon_config['log-opts']['max-size'] }})
+          (expected {{ docker_log_max_size }})
 
     - name: Assert log-opts max-file matches variable
       ansible.builtin.assert:
         that:
-          - "_docker_verify_daemon_dict['log-opts']['max-file'] == docker_daemon_config['log-opts']['max-file']"
+          - "_docker_verify_daemon_dict['log-opts']['max-file'] == docker_log_max_file"
         fail_msg: >-
-          log-opts.max-file not set to '{{ docker_daemon_config['log-opts']['max-file'] | default('') }}' in daemon.json
+          log-opts.max-file not set to '{{ docker_log_max_file | default('') }}' in daemon.json
         success_msg: >-
           log-opts.max-file={{ _docker_verify_daemon_dict['log-opts']['max-file'] }}
-          (expected {{ docker_daemon_config['log-opts']['max-file'] }})
+          (expected {{ docker_log_max_file }})
 
     # ---- Security settings ----
 
@@ -251,10 +251,10 @@
 
         - name: Assert logging driver matches
           ansible.builtin.assert:
-            that: "_docker_verify_info['LoggingDriver'] == docker_daemon_config['log-driver']"
+            that: "_docker_verify_info['LoggingDriver'] == docker_log_driver"
             fail_msg: >-
               Docker logging driver mismatch:
-              expected '{{ docker_daemon_config['log-driver'] | default('') }}',
+              expected '{{ docker_log_driver | default('') }}',
               got '{{ _docker_verify_info['LoggingDriver'] }}'
             success_msg: >-
               Logging driver matches: {{ _docker_verify_info['LoggingDriver'] }}

--- a/ansible/roles/docker/molecule/vagrant/molecule.yml
+++ b/ansible/roles/docker/molecule/vagrant/molecule.yml
@@ -47,6 +47,7 @@ provisioner:
         docker_enable_service: true
         docker_manage_daemon: true
         docker_user: "vagrant"
+        docker_daemon_overwrite: {}
     host_vars:
       arch-vm:
         docker_userns_remap: ""

--- a/ansible/roles/docker/molecule/vagrant/molecule.yml
+++ b/ansible/roles/docker/molecule/vagrant/molecule.yml
@@ -32,11 +32,9 @@ provisioner:
   inventory:
     group_vars:
       all:
-        docker_daemon_config:
-          log-driver: "journald"
-          log-opts:
-            max-size: "10m"
-            max-file: "3"
+        docker_log_driver: "journald"
+        docker_log_max_size: "10m"
+        docker_log_max_file: "3"
         docker_daemon_overwrite: {}
         docker_storage_driver: ""
         docker_userns_remap: "default"
@@ -47,27 +45,22 @@ provisioner:
         docker_enable_service: true
         docker_manage_daemon: true
         docker_user: "vagrant"
-        docker_daemon_overwrite: {}
     host_vars:
       arch-vm:
         docker_userns_remap: ""
         docker_icc: true
-        docker_daemon_config:
-          log-driver: "json-file"
-          log-opts:
-            max-size: "10m"
-            max-file: "3"
+        docker_log_driver: "json-file"
+        docker_log_max_size: "10m"
+        docker_log_max_file: "3"
         docker_live_restore: false
         docker_no_new_privileges: false
         docker_storage_driver: "vfs"
       ubuntu-base:
         docker_userns_remap: ""
         docker_icc: true
-        docker_daemon_config:
-          log-driver: "json-file"
-          log-opts:
-            max-size: "10m"
-            max-file: "3"
+        docker_log_driver: "json-file"
+        docker_log_max_size: "10m"
+        docker_log_max_file: "3"
         docker_live_restore: false
         docker_no_new_privileges: false
         docker_enable_service: false

--- a/ansible/roles/docker/tasks/main.yml
+++ b/ansible/roles/docker/tasks/main.yml
@@ -54,27 +54,27 @@
         group: root
         mode: '0755'
 
-    - name: "CIS 2.1, 2.8, 2.14, 5.25 | Build Docker daemon security configuration"
+    - name: "CIS 2.1, 2.8, 2.14, 5.25 | Build Docker daemon configuration"
       ansible.builtin.set_fact:
-        _docker_daemon_security: >-
+        _docker_merged_config: >-
           {{
-            {}
+            {
+              "log-driver": docker_log_driver,
+              "log-opts": {
+                "max-size": docker_log_max_size,
+                "max-file": docker_log_max_file
+              }
+            }
+            | combine({"storage-driver": docker_storage_driver} if docker_storage_driver | length > 0 else {})
             | combine({"userns-remap": docker_userns_remap} if docker_userns_remap | string | length > 0 else {})
             | combine({"icc": false} if not (docker_icc | bool) else {})
             | combine({"live-restore": true} if docker_live_restore | bool else {})
             | combine({"no-new-privileges": true} if docker_no_new_privileges | bool else {})
-            | combine({"storage-driver": docker_storage_driver} if docker_storage_driver | length > 0 else {})
+            | combine(docker_daemon_overwrite, recursive=True)
           }}
       tags: ['security', 'cis_2.1', 'cis_2.8', 'cis_2.14', 'cis_5.25']
 
-    - name: Build final Docker daemon configuration
-      ansible.builtin.set_fact:
-        _docker_daemon_final: >-
-          {{ docker_daemon_config
-             | combine(_docker_daemon_security, recursive=True)
-             | combine(docker_daemon_overwrite, recursive=True) }}
-
-    - name: Deploy Docker daemon.json
+    - name: "CIS 2.8 | CIS 2.1 | CIS 2.14 — Deploy Docker daemon.json"
       ansible.builtin.template:
         src: daemon.json.j2
         dest: /etc/docker/daemon.json
@@ -83,6 +83,7 @@
         mode: '0644'
         validate: 'python3 -m json.tool %s'
       notify: Restart docker
+      tags: ['docker', 'docker:configure', 'security', 'cis_2.8', 'cis_2.1', 'cis_2.14']
 
 - name: "Report: Configure daemon"
   ansible.builtin.include_role:
@@ -93,7 +94,7 @@
     common_rpt_phase: "Configure daemon"
     common_rpt_status: "{{ 'done' if docker_manage_daemon | bool else 'skip' }}"
     common_rpt_detail: >-
-      {{ 'log=' ~ docker_daemon_config['log-driver'] ~ ' icc=' ~ (docker_icc | string)
+      {{ 'log=' ~ docker_log_driver ~ ' icc=' ~ (docker_icc | string)
          if docker_manage_daemon | bool else 'disabled' }}
   tags: ['docker', 'report']
 
@@ -105,6 +106,25 @@
   ansible.builtin.group:
     name: docker
     state: present
+  when: docker_add_user_to_group | bool
+  tags: ['docker', 'docker:configure']
+
+- name: Check target user exists before group addition  # noqa: command-instead-of-module
+  ansible.builtin.command: "id {{ docker_user }}"
+  register: _docker_user_check
+  changed_when: false
+  failed_when: false
+  when: docker_add_user_to_group | bool
+  tags: ['docker', 'docker:configure']
+
+- name: Assert target user exists
+  ansible.builtin.assert:
+    that:
+      - _docker_user_check.rc == 0
+    fail_msg: >-
+      User '{{ docker_user }}' does not exist.
+      Cannot add non-existent user to docker group.
+    success_msg: "User '{{ docker_user }}' exists"
   when: docker_add_user_to_group | bool
   tags: ['docker', 'docker:configure']
 
@@ -168,12 +188,11 @@
   vars:
     common_rpt_fact: "_docker_phases"
     common_rpt_phase: "Verify"
-    common_rpt_detail: >-
-      daemon.json OK
+    common_rpt_detail: "daemon.json + permissions"
   tags: ['docker', 'report']
 
 # ======================================================================
-# ---- Отчёт ----
+# ---- Execution Report ----
 # ======================================================================
 
 - name: "Docker — Execution Report"

--- a/ansible/roles/docker/templates/daemon.json.j2
+++ b/ansible/roles/docker/templates/daemon.json.j2
@@ -1,1 +1,1 @@
-{{ _docker_daemon_final | to_nice_json }}
+{{ _docker_merged_config | to_nice_json }}


### PR DESCRIPTION
Addresses the docker role audit findings tracked in #93.

## What changed
- add ROLE-008 structured reporting for daemon configuration, user group management, service handling, verification, and final role execution summary
- rename the computed daemon config fact and support `docker_daemon_overwrite` for recursive custom `daemon.json` overrides
- add CIS control tags to the daemon hardening task and validate that the target user exists before adding it to the `docker` group
- document variable safety levels directly in role defaults and expand the README with execution flow, examples, cross-platform notes, logs, troubleshooting, testing, tags, and file map
- declare the `common` role dependency and initialize `docker_daemon_overwrite` in both molecule scenarios

## Audit findings addressed
- ROLE-008 reporting is now implemented in the role execution flow
- ROLE-004 security controls are reflected in task tags for Docker daemon hardening
- README coverage is expanded to include the missing operational sections from the audit
- variables now distinguish safe, careful, and internal settings
- the role now fails early when `docker_user` does not exist before group membership changes

## Testing
- CI

## Linked issues
- Closes #93
