### PR TITLE
fix(teleport): audit compliance — README, molecule, wiki

### DIFF
--- a/ansible/roles/teleport/README.md
+++ b/ansible/roles/teleport/README.md
@@ -10,7 +10,7 @@ Installs and configures a Teleport node agent for zero-trust SSH access with cer
 4. **Validate join config** (`tasks/join.yml`) — validates join token configuration
 5. **Install** (`tasks/install.yml`, when `teleport_manage_install: true`) — installs Teleport via package manager (Arch), official APT/YUM repo (Debian/RedHat), or binary CDN download (Void/Gentoo). Binary path: version-checks existing install, downloads only if needed, deploys systemd unit file if `service_mgr == systemd`. **Triggers handler:** daemon-reload if unit file changes.
 6. **Configure** (`tasks/configure.yml`, when `teleport_manage_config: true`) — creates `/var/lib/teleport` (0750), deploys `/etc/teleport.yaml` (0600, no_log). **Triggers handler:** "Restart teleport" if config changes.
-7. **CA export** (`tasks/ca_export.yml`, when `teleport_export_ca_key: true`) — reads Teleport user CA from auth server via `tctl auth export`, writes to `teleport_ca_keys_file`, sets `ssh_teleport_integration: true` fact for the `ssh` role.
+7. **CA export** (`tasks/ca_export.yml`, when `teleport_export_ca_key: true`) — reads Teleport user CA from auth server via `tctl auth export`, writes to `teleport_ca_keys_file`, sets `teleport_ca_deployed: true` fact (the `ssh` role reads this to derive `ssh_teleport_integration`).
 8. **Service** (when `teleport_manage_service: true`) — enables and starts `teleport` service via `ansible.builtin.service` (init-system agnostic).
 9. **Verify** (`tasks/verify.yml`) — checks binary responds to `teleport version`, config file exists with mode 0600, reports service status (does not assert running state — requires live cluster).
 10. **Report** — writes execution summary via `common/report_phase.yml` and `common/report_render.yml`.

--- a/ansible/roles/teleport/README.md
+++ b/ansible/roles/teleport/README.md
@@ -1,173 +1,225 @@
 # teleport
 
-Teleport SSH access platform agent — installs and configures a Teleport node for zero-trust SSH access with certificate authority integration.
+Installs and configures a Teleport node agent for zero-trust SSH access with certificate authority integration.
 
-## What this role does
+## Execution flow
 
-- [x] Installs Teleport via package manager (Arch), official repository (Debian/RedHat), or binary download (Void/Gentoo)
-- [x] Architecture-aware binary downloads: `x86_64` → `amd64`, `aarch64` → `arm64`
-- [x] Validates `teleport_auth_server` and `teleport_join_token` before proceeding (fail-fast)
-- [x] Deploys `/etc/teleport.yaml` (v3 format) with auth server address, join token, node name, and labels
-- [x] Configures session recording mode (`node`, `proxy`, or `off`)
-- [x] Optional BPF-based enhanced session recording
-- [x] Exports Teleport user CA public key and sets the `ssh_teleport_integration` fact for the `ssh` role
-- [x] Init-system agnostic service management (systemd, runit, openrc, s6, dinit)
-- [x] Verifies Teleport binary version, config file permissions (0600), and service status
+1. **Assert OS** — fails immediately if `ansible_facts['os_family']` is not in the supported list (Archlinux, Debian, RedHat, Void, Gentoo)
+2. **Load OS variables** — includes `vars/<os_family>.yml` (package names, service names)
+3. **Assert auth server** — fails if `teleport_auth_server` is empty
+4. **Validate join config** (`tasks/join.yml`) — validates join token configuration
+5. **Install** (`tasks/install.yml`, when `teleport_manage_install: true`) — installs Teleport via package manager (Arch), official APT/YUM repo (Debian/RedHat), or binary CDN download (Void/Gentoo). Binary path: version-checks existing install, downloads only if needed, deploys systemd unit file if `service_mgr == systemd`. **Triggers handler:** daemon-reload if unit file changes.
+6. **Configure** (`tasks/configure.yml`, when `teleport_manage_config: true`) — creates `/var/lib/teleport` (0750), deploys `/etc/teleport.yaml` (0600, no_log). **Triggers handler:** "Restart teleport" if config changes.
+7. **CA export** (`tasks/ca_export.yml`, when `teleport_export_ca_key: true`) — reads Teleport user CA from auth server via `tctl auth export`, writes to `teleport_ca_keys_file`, sets `ssh_teleport_integration: true` fact for the `ssh` role.
+8. **Service** (when `teleport_manage_service: true`) — enables and starts `teleport` service via `ansible.builtin.service` (init-system agnostic).
+9. **Verify** (`tasks/verify.yml`) — checks binary responds to `teleport version`, config file exists with mode 0600, reports service status (does not assert running state — requires live cluster).
+10. **Report** — writes execution summary via `common/report_phase.yml` and `common/report_render.yml`.
 
-## Requirements
+### Handlers
 
-**Supported distributions** (enforced via `assert` at role entry):
+| Handler | Triggered by | What it does |
+|---------|-------------|--------------|
+| `restart teleport` | Config file change (step 6) | Restarts teleport service via `ansible.builtin.service`. |
 
-| OS Family | Distros |
-|-----------|---------|
-| Archlinux | Arch Linux |
-| Debian | Debian, Ubuntu |
-| RedHat | Fedora, RHEL, CentOS |
-| Void | Void Linux |
-| Gentoo | Gentoo |
+## Variables
 
-**Supported init systems:** systemd, runit, openrc, s6, dinit
+### Configurable (`defaults/main.yml`)
 
-**Ansible version:** ≥ 2.15
+Override these via inventory (`group_vars/` or `host_vars/`), never edit `defaults/main.yml` directly.
 
-**Runtime requirement:** A reachable Teleport cluster (auth server + join token) is required for the service to start successfully. The role will install and configure the agent regardless, but `teleport.service` will fail to join without a live cluster.
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `teleport_enabled` | `true` | safe | Set `false` to skip the entire role |
+| `teleport_manage_install` | `true` | safe | Set `false` to skip installation (useful if Teleport is pre-installed) |
+| `teleport_manage_config` | `true` | safe | Set `false` to skip config deployment (manage config separately) |
+| `teleport_manage_service` | `true` | safe | Set `false` to skip service enable/start |
+| `teleport_version` | `"17.4.10"` | careful | Full semver string. Used for binary downloads and major version for package repos. Must match an available release. |
+| `teleport_auth_server` | `""` | careful | **Required.** Auth/proxy server address, e.g. `auth.example.com:443`. Role fails if empty. |
+| `teleport_join_token` | `""` | careful | **Required.** Join token for cluster registration. |
+| `teleport_node_name` | `{{ ansible_hostname }}` | safe | Node name shown in the Teleport UI |
+| `teleport_labels` | `{}` | safe | Key-value map of node labels for RBAC role assignment |
+| `teleport_ssh_enabled` | `true` | careful | Enable the SSH service on this node. Set `false` for proxy-only nodes. |
+| `teleport_proxy_mode` | `false` | careful | Run as a proxy node. Changes the role of this node in the cluster. |
+| `teleport_session_recording` | `"node"` | careful | Session recording location: `node`, `proxy`, or `off`. Affects where session data is stored. |
+| `teleport_enhanced_recording` | `false` | internal | BPF-based enhanced session recording. Requires Linux kernel ≥ 5.8 with BTF enabled. Breaking change if kernel doesn't support it. |
+| `teleport_export_ca_key` | `true` | safe | Export Teleport user CA and configure `ssh` role integration |
+| `teleport_ca_keys_file` | `/etc/ssh/teleport_user_ca.pub` | careful | Destination path for the exported CA public key. Must match `TrustedUserCAKeys` in `sshd_config`. |
+| `teleport_config_overwrite` | `{}` | careful | Dict merged on top of the rendered `teleport.yaml`. Allows injecting arbitrary keys without modifying the template. |
 
-## Role Variables
+### Internal mappings (`vars/`)
 
-| Variable | Default | Required | Description |
-|----------|---------|----------|-------------|
-| `teleport_enabled` | `true` | No | Enable/disable the entire role |
-| `teleport_version` | `"17.0.0"` | No | Full semver string; used for binary downloads; major version is auto-extracted for package repos |
-| `teleport_auth_server` | `""` | **Yes** | Auth/proxy server address, e.g. `auth.example.com:443` |
-| `teleport_join_token` | `""` | **Yes** | Join token (static or IAM-based) for cluster registration |
-| `teleport_node_name` | `{{ ansible_hostname }}` | No | Node name shown in the Teleport UI |
-| `teleport_labels` | `{}` | No | Key-value map of labels for RBAC role assignment |
-| `teleport_ssh_enabled` | `true` | No | Enable the SSH service on this node |
-| `teleport_proxy_mode` | `false` | No | Run as a proxy node instead of a regular SSH node |
-| `teleport_session_recording` | `"node"` | No | Session recording location: `node`, `proxy`, or `off` |
-| `teleport_enhanced_recording` | `false` | No | Enable BPF-based enhanced session recording (requires kernel ≥ 5.8) |
-| `teleport_export_ca_key` | `true` | No | Export Teleport user CA and configure `ssh` role integration |
-| `teleport_ca_keys_file` | `/etc/ssh/teleport_user_ca.pub` | No | Destination path for the exported CA public key |
+These files contain cross-platform mappings. Do not override via inventory — edit directly only when adding new platform support.
 
-## Installation Methods
+| File | What it contains | When to edit |
+|------|-----------------|-------------|
+| `vars/main.yml` | Service name map per init system (`teleport` for all) | Adding a new init system |
+| `vars/archlinux.yml` | Package list: `teleport-bin` (AUR) | Changing the AUR package name |
+| `vars/debian.yml` | Package list: empty (repo method installs directly) | If Debian switches to a package-based install |
+| `vars/redhat.yml` | Package list: mirrors Debian pattern | Same as Debian |
+| `vars/void.yml` | Package list: empty (binary method) | If Void gets an official package |
+| `vars/gentoo.yml` | Package list: empty (binary method) | If Gentoo gets an official package |
 
-The install method is determined per OS family by `vars/<os_family>.yml` — not user-facing:
+## Examples
 
-| OS Family | Distros | Method | Notes |
-|-----------|---------|--------|-------|
-| Archlinux | Arch | `package` | Installs `teleport-bin` from AUR (requires AUR helper or pre-installed package) |
-| Debian | Debian, Ubuntu | `repo` | Adds `apt.releases.teleport.dev` APT repo then installs `teleport` |
-| RedHat | Fedora, RHEL | `repo` | Adds `yum.releases.teleport.dev` YUM repo then installs `teleport` |
-| Void | Void Linux | `binary` | Downloads tarball from `cdn.teleport.dev`, extracts to `/usr/local/bin/` |
-| Gentoo | Gentoo | `binary` | Same as Void; no official Gentoo package available |
-
-`teleport_version` controls the version fetched for `repo` and `binary` methods (major version for repos, full semver for binary URLs).
-
-## Usage
-
-Minimal playbook — provide the two required variables:
+### Minimal required configuration
 
 ```yaml
-- name: Deploy workstation
-  hosts: workstations
-  become: true
-  roles:
-    - role: teleport
-      vars:
-        teleport_auth_server: "auth.example.com:443"
-        teleport_join_token: "{{ vault_teleport_join_token }}"
+# In host_vars/<hostname>/teleport.yml:
+teleport_auth_server: "auth.example.com:443"
+teleport_join_token: "{{ vault_teleport_join_token }}"
 ```
 
-With labels and enhanced recording:
+### With labels and proxy-mode recording
 
 ```yaml
-- role: teleport
-  vars:
-    teleport_auth_server: "auth.example.com:443"
-    teleport_join_token: "{{ vault_teleport_join_token }}"
-    teleport_labels:
-      env: production
-      role: workstation
-    teleport_session_recording: "proxy"
-    teleport_enhanced_recording: true
+# In group_vars/workstations/teleport.yml:
+teleport_auth_server: "auth.example.com:443"
+teleport_join_token: "{{ vault_teleport_join_token }}"
+teleport_labels:
+  env: production
+  role: workstation
+teleport_session_recording: "proxy"
+teleport_enhanced_recording: true
 ```
 
-**Run order:** When using the `ssh` role alongside this role, `teleport` must run first so the CA fact is available before `sshd_config` is rendered.
+- `teleport_session_recording: "proxy"` — session data stored at the proxy instead of the node. Reduces node disk usage.
+- `teleport_enhanced_recording: true` — BPF-based recording. Requires kernel ≥ 5.8 with BTF. Do not enable on older kernels.
 
-## Service Management
+### Disabling the role on a specific host
 
-The Teleport agent is enabled and started as part of the role. The service name is mapped per init system in `vars/<os_family>.yml` (all supported init systems map to `teleport`).
-
-> **Important:** The service requires a reachable auth server and a valid join token to start successfully. If neither is available (e.g. in CI or staging environments), set `teleport_enabled: false` or mock the variables and skip the service step with `--skip-tags teleport,service`.
-
-To restart the service without re-applying the full configuration:
-
-```
-ansible-playbook workstation.yml --tags teleport,service
+```yaml
+# In host_vars/<hostname>/teleport.yml:
+teleport_enabled: false
 ```
 
-## CA Export and `ssh` Role Integration
+### Injecting extra teleport.yaml keys without modifying the template
 
-When `teleport_export_ca_key: true` (the default), the role:
-
-1. Reads the Teleport user CA public key from the auth server via `tctl auth export`.
-2. Writes it to `teleport_ca_keys_file` (default: `/etc/ssh/teleport_user_ca.pub`).
-3. Sets the Ansible fact `ssh_teleport_integration: true`.
-
-The `ssh` role detects this fact and adds:
-
-```
-TrustedUserCAKeys /etc/ssh/teleport_user_ca.pub
+```yaml
+# In host_vars/<hostname>/teleport.yml:
+teleport_config_overwrite:
+  teleport:
+    diag_addr: "0.0.0.0:3000"
 ```
 
-to `sshd_config`, allowing Teleport-issued short-lived certificates to authenticate without pre-deployed `authorized_keys` entries. This is the recommended zero-trust configuration.
+### Skip CA export (when not using the ssh role)
 
-Set `teleport_export_ca_key: false` if the `ssh` role is not in use or if managing `sshd_config` separately.
+```yaml
+# In group_vars/all/teleport.yml:
+teleport_export_ca_key: false
+```
+
+## Cross-platform details
+
+| Aspect | Arch Linux | Ubuntu / Debian | Fedora / RHEL | Void Linux | Gentoo |
+|--------|-----------|-----------------|---------------|------------|--------|
+| Install method | `package` (AUR) | `repo` (APT) | `repo` (YUM) | `binary` (CDN) | `binary` (CDN) |
+| Package name | `teleport-bin` | `teleport` | `teleport` | — | — |
+| Binary path (binary method) | — | — | — | `/usr/local/bin/teleport` | `/usr/local/bin/teleport` |
+| Config path | `/etc/teleport.yaml` | `/etc/teleport.yaml` | `/etc/teleport.yaml` | `/etc/teleport.yaml` | `/etc/teleport.yaml` |
+| Data directory | `/var/lib/teleport` | `/var/lib/teleport` | `/var/lib/teleport` | `/var/lib/teleport` | `/var/lib/teleport` |
+| Service name | `teleport` | `teleport` | `teleport` | `teleport` | `teleport` |
+| Systemd unit | package-provided | package-provided | package-provided | deployed by role | deployed by role |
+
+## Logs
+
+### Log sources
+
+| Source | How to access | Contents |
+|--------|--------------|---------- |
+| Service output | `journalctl -u teleport -f` | Cluster join attempts, SSH session events, auth failures, config errors |
+| Session recordings | `/var/lib/teleport/log/` | BPF or PTY session recording data (local node recording only) |
+| Diagnostics endpoint | `http://localhost:3000/metrics` | Prometheus metrics (when `teleport_config_overwrite.teleport.diag_addr` is set) |
+
+Teleport does not write standalone log files by default — all output goes to the system journal. There is no built-in log rotation configuration; journal rotation applies.
+
+### Reading the logs
+
+- **Failed to join cluster:** `journalctl -u teleport -n 100 | grep -i "error\|failed\|join"` — look for TLS errors, token expiry, or unreachable auth server.
+- **Service won't start:** `journalctl -u teleport -n 50` — usually a config syntax error or missing `auth_server`.
+- **Check config parsed correctly:** `teleport configure check --config /etc/teleport.yaml`
+
+## Troubleshooting
+
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| Role fails at "Assert auth server is configured" | `teleport_auth_server` is empty or not set | Set `teleport_auth_server: "auth.example.com:443"` in inventory |
+| `teleport.service` fails to start | `journalctl -u teleport -n 50` | Usually wrong `auth_server` address or expired `join_token`. Verify cluster is reachable: `curl -k https://<auth_server>/webapi/ping` |
+| Service starts but immediately exits | `journalctl -u teleport -n 100 \| grep error` | TLS certificate errors: clock skew > 5 min causes TLS rejection. Run `chronyc tracking`. Also check firewall allows outbound to auth server port. |
+| `/etc/teleport.yaml` has wrong permissions | `stat /etc/teleport.yaml` | Role sets 0600 on deploy. If permissions changed externally: re-run with `--tags teleport` |
+| CA export fails | `journalctl -u teleport -n 30` | CA export requires a running auth server with `tctl` access. Set `teleport_export_ca_key: false` for nodes without cluster access. |
+| AUR package install fails on Arch | Check `ansible output` for pacman errors | `teleport-bin` is an AUR package — requires an AUR helper. Install via binary method: `teleport_install_method: binary` in host_vars. |
+| Idempotence failure on config deploy | `molecule converge` runs twice and shows `changed` | A Jinja2 expression in `templates/teleport.yaml.j2` produces non-deterministic output. Check for filters that change on each run. |
+
+## Testing
+
+Two scenarios are required for every role. Run Docker for fast feedback, Vagrant for full validation.
+
+| Scenario | Command | When to use | What it tests |
+|----------|---------|-------------|---------------|
+| `default` (localhost) | `molecule test -s default` | Smoke test: after changing templates or variables | Syntax, variable loading, config rendered with correct content and 0600 permissions |
+| `docker` | `molecule test -s docker` | After changing task logic, service management, or install paths | Package install, service enabled, idempotence, Arch + Ubuntu matrix |
+| `vagrant` | `molecule test -s vagrant` | After changing OS-specific logic or before releasing | Real systemd, real packages, Arch + Ubuntu multi-distro validation |
+
+### Success criteria
+
+- All steps complete: `syntax → converge → idempotence → verify → destroy`
+- Idempotence step: `changed=0` (second run changes nothing)
+- Verify step: all `ansible.builtin.assert` tasks pass
+- Final line: no `failed` tasks
+
+### What the tests verify
+
+| Category | Examples | Test requirement |
+|----------|----------|-----------------|
+| Binary | `teleport` in PATH, `teleport version` exits 0 | TEST-008 |
+| Config file | `/etc/teleport.yaml` exists, mode 0600, owned root | TEST-008 |
+| Config content | schema `v3`, correct node name, auth server, session recording mode | TEST-008 |
+| Data directory | `/var/lib/teleport` exists, mode 0750 | TEST-008 |
+| Systemd unit | `teleport.service` present, mode 0644, enabled (systemd only) | TEST-008 |
+| Skip path | `teleport_enabled: false` runs without error and installs nothing | TEST-011 |
+
+### Common test failures
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `which: no teleport in PATH` | Binary install failed silently | Check `teleport_install_method` for the platform; check CDN URL is reachable in Docker |
+| Idempotence failure: `/etc/teleport.yaml` changed | Non-deterministic template output | Check `teleport.yaml.j2` for filters that change on each run; `no_log: true` on task hides diff |
+| `Assert /etc/teleport.yaml exists` fails | `teleport_manage_config: false` was set in converge | Remove the override or check converge vars match what verify expects |
+| `Assert teleport.service unit file exists` fails | Non-systemd container, or binary not deployed | Unit file section is guarded by `service_mgr == systemd`; check if container actually uses systemd |
+| Vagrant: `Python not found` | `prepare.yml` platform dispatch failed | Check `prepare_archlinux.yml` and `prepare_debian.yml` exist and `ansible_facts['os_family']` resolves |
 
 ## Tags
 
-| Tag | Scope |
-|-----|-------|
-| `teleport` | All tasks |
-| `teleport`, `install` | Package/binary installation only |
-| `teleport`, `security` | Join token validation and CA export |
-| `teleport`, `service` | Service enable/start only |
-| `teleport`, `report` | Execution report (skippable in CI) |
+| Tag | What it runs | Use case |
+|-----|-------------|----------|
+| `teleport` | Entire role | Full apply: `ansible-playbook workstation.yml --tags teleport` |
+| `teleport,install` | Installation only | Upgrade Teleport binary without touching config: `ansible-playbook workstation.yml --tags teleport,install` |
+| `teleport,security` | Join token validation + CA export | Re-export CA after cluster rotation: `ansible-playbook workstation.yml --tags teleport,security` |
+| `teleport,service` | Service enable/start only | Restart service without re-deploying config: `ansible-playbook workstation.yml --tags teleport,service` |
+| `teleport,report` | Execution report only | Re-generate report in CI: `ansible-playbook workstation.yml --tags teleport,report` |
 
-## Testing (Molecule)
+## File map
 
-Three scenarios covering offline validation, containerized systemd, and full VM testing:
-
-| Scenario | Driver | Platform | What is tested |
-|----------|--------|----------|----------------|
-| `default` | `default` (localhost) | Localhost (Arch) | Syntax, variable loading, config file rendered with correct content and `0600` permissions, data directory exists |
-| `docker` | Docker | `arch-systemd` container | All of the above plus: package install, service enabled/running, idempotency |
-| `vagrant` | Vagrant | Arch Linux VM + Ubuntu Noble VM | Multi-distro install paths (`package` on Arch, `repo` on Ubuntu), service join (requires mock cluster or skip) |
-
-**What is not testable without a live Teleport cluster:**
-
-- Actual cluster join (`teleport.service` reaching `Running` state)
-- CA export (`teleport_export_ca_key: true`) — requires `tctl` connected to a live auth server
-- Session recording validation
-
-Run a scenario:
-
-```bash
-cd ansible/roles/teleport
-molecule test -s default      # offline smoke test
-molecule test -s docker       # containerized systemd (requires Docker)
-molecule test -s vagrant      # full VM (requires Vagrant + libvirt/VirtualBox)
-```
-
-## Known Limitations
-
-| Limitation | Details |
-|------------|---------|
-| AUR package not testable in CI | `teleport-bin` is an AUR package; standard CI containers use official repos or binary installs |
-| Service requires live cluster | `teleport.service` will fail to reach `Running` without a valid `auth_server` + `join_token` |
-| Binary install lacks service unit | Void/Gentoo binary installs do not include a systemd unit; a service unit must be provided separately if systemd is the init system |
-| `tctl` dependency for CA export | CA export requires `tctl` to be available and authenticated against the cluster; not available in offline/CI runs |
-| Enhanced recording kernel requirement | BPF-based enhanced session recording (`teleport_enhanced_recording: true`) requires Linux kernel ≥ 5.8 with BTF enabled |
+| File | Purpose | Edit? |
+|------|---------|-------|
+| `defaults/main.yml` | All configurable settings | No — override via inventory |
+| `vars/main.yml` | Service name map per init system | Only when adding init system support |
+| `vars/<os_family>.yml` | Package names per distro family | Only when adding distro support |
+| `templates/teleport.yaml.j2` | Teleport config template (v3 format) | When changing config structure |
+| `tasks/main.yml` | Execution flow orchestrator | When adding/removing phases |
+| `tasks/install.yml` | Install Teleport (package/repo/binary) | When changing install logic |
+| `tasks/configure.yml` | Deploy `/etc/teleport.yaml` | When changing config deploy logic |
+| `tasks/ca_export.yml` | Export CA key + set ssh integration fact | When changing CA export behavior |
+| `tasks/join.yml` | Validate join token configuration | When changing join validation |
+| `tasks/verify.yml` | Post-deploy self-check | When changing verification logic |
+| `handlers/main.yml` | Service restart handler | Rarely |
+| `molecule/default/` | Localhost smoke test scenario | When changing smoke test coverage |
+| `molecule/docker/` | Docker containerized test scenario | When changing Docker test coverage |
+| `molecule/vagrant/` | Full VM test scenario | When changing multi-distro coverage |
+| `molecule/shared/converge.yml` | Shared converge playbook (all scenarios) | When changing test variables or adding edge cases |
+| `molecule/shared/verify.yml` | Shared verify playbook (all scenarios) | When adding verification assertions |
+| `requirements.yml` | Role dependency declaration (common role) | When adding role dependencies |
+| `meta/main.yml` | Role metadata | Rarely |
 
 ## License
 

--- a/ansible/roles/teleport/molecule/default/converge.yml
+++ b/ansible/roles/teleport/molecule/default/converge.yml
@@ -1,4 +1,5 @@
 ---
 # TEST-003: Stub converge for default scenario.
 # Delegates to the shared converge playbook so all scenarios share one source of truth.
-- ansible.builtin.import_playbook: ../shared/converge.yml
+- name: Converge
+  ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/teleport/molecule/default/molecule.yml
+++ b/ansible/roles/teleport/molecule/default/molecule.yml
@@ -1,4 +1,8 @@
 ---
+# NOTE (TEST-013): This scenario runs on localhost only — it is an offline smoke
+# test designed for syntax checking, variable loading, and config rendering.
+# Cross-platform coverage (Arch + Ubuntu) is provided by the docker and vagrant
+# scenarios which run real containers/VMs with actual package installs.
 driver:
   name: default
   options:
@@ -19,9 +23,6 @@ provisioner:
     host_vars:
       Localhost:
         ansible_connection: local
-  playbooks:
-    converge: ../shared/converge.yml
-    verify: ../shared/verify.yml
   env:
     ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
 

--- a/ansible/roles/teleport/molecule/default/verify.yml
+++ b/ansible/roles/teleport/molecule/default/verify.yml
@@ -1,0 +1,4 @@
+---
+# TEST-003: Stub verify for default scenario.
+# Delegates to the shared verify playbook so all scenarios share one source of truth.
+- ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/teleport/molecule/default/verify.yml
+++ b/ansible/roles/teleport/molecule/default/verify.yml
@@ -1,4 +1,5 @@
 ---
 # TEST-003: Stub verify for default scenario.
 # Delegates to the shared verify playbook so all scenarios share one source of truth.
-- ansible.builtin.import_playbook: ../shared/verify.yml
+- name: Verify
+  ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/teleport/molecule/docker/converge.yml
+++ b/ansible/roles/teleport/molecule/docker/converge.yml
@@ -1,4 +1,4 @@
 ---
-# TEST-003: Stub converge for default scenario.
+# TEST-003: Stub converge for docker scenario.
 # Delegates to the shared converge playbook so all scenarios share one source of truth.
 - ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/teleport/molecule/docker/converge.yml
+++ b/ansible/roles/teleport/molecule/docker/converge.yml
@@ -1,4 +1,5 @@
 ---
 # TEST-003: Stub converge for docker scenario.
 # Delegates to the shared converge playbook so all scenarios share one source of truth.
-- ansible.builtin.import_playbook: ../shared/converge.yml
+- name: Converge
+  ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/teleport/molecule/docker/molecule.yml
+++ b/ansible/roles/teleport/molecule/docker/molecule.yml
@@ -51,8 +51,6 @@ provisioner:
         teleport_install_method: binary
   playbooks:
     prepare: prepare.yml
-    converge: ../shared/converge.yml
-    verify: ../shared/verify.yml
 
 verifier:
   name: ansible

--- a/ansible/roles/teleport/molecule/docker/prepare.yml
+++ b/ansible/roles/teleport/molecule/docker/prepare.yml
@@ -4,19 +4,5 @@
   become: true
   gather_facts: true
   tasks:
-    - name: Update pacman package cache (Arch)
-      community.general.pacman:
-        update_cache: true
-      when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Update apt cache (Ubuntu)
-      ansible.builtin.apt:
-        update_cache: true
-        cache_valid_time: 3600
-      when: ansible_facts['os_family'] == 'Debian'
-
-    - name: Install ca-certificates (Ubuntu)
-      ansible.builtin.apt:
-        name: ca-certificates
-        state: present
-      when: ansible_facts['os_family'] == 'Debian'
+    - name: Run OS-specific prepare tasks
+      ansible.builtin.include_tasks: "prepare_{{ ansible_facts['os_family'] | lower }}.yml"

--- a/ansible/roles/teleport/molecule/docker/prepare_archlinux.yml
+++ b/ansible/roles/teleport/molecule/docker/prepare_archlinux.yml
@@ -1,0 +1,4 @@
+---
+- name: Update pacman package cache
+  community.general.pacman:
+    update_cache: true

--- a/ansible/roles/teleport/molecule/docker/prepare_debian.yml
+++ b/ansible/roles/teleport/molecule/docker/prepare_debian.yml
@@ -1,0 +1,10 @@
+---
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install ca-certificates
+  ansible.builtin.apt:
+    name: ca-certificates
+    state: present

--- a/ansible/roles/teleport/molecule/docker/verify.yml
+++ b/ansible/roles/teleport/molecule/docker/verify.yml
@@ -1,4 +1,5 @@
 ---
 # TEST-003: Stub verify for docker scenario.
 # Delegates to the shared verify playbook so all scenarios share one source of truth.
-- ansible.builtin.import_playbook: ../shared/verify.yml
+- name: Verify
+  ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/teleport/molecule/docker/verify.yml
+++ b/ansible/roles/teleport/molecule/docker/verify.yml
@@ -1,0 +1,4 @@
+---
+# TEST-003: Stub verify for docker scenario.
+# Delegates to the shared verify playbook so all scenarios share one source of truth.
+- ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/teleport/molecule/shared/verify.yml
+++ b/ansible/roles/teleport/molecule/shared/verify.yml
@@ -22,9 +22,10 @@
     # -----------------------------------------------------------------------
     # 1. Teleport binary
     # -----------------------------------------------------------------------
-    - name: Check teleport binary is in PATH (which)
-      ansible.builtin.command:
-        cmd: which teleport
+    - name: Check teleport binary is in PATH (command -v)
+      ansible.builtin.shell:
+        cmd: command -v teleport
+        executable: /bin/bash
       register: _teleport_verify_which
       changed_when: false
       failed_when: _teleport_verify_which.rc != 0

--- a/ansible/roles/teleport/molecule/shared/verify.yml
+++ b/ansible/roles/teleport/molecule/shared/verify.yml
@@ -1,17 +1,30 @@
 ---
+# Verification categories skipped:
+#   runtime — 'teleport status' requires a live auth server; not available in molecule.
+#             Service start is verified (systemctl is-enabled), but active/running state
+#             is not asserted because the service cannot join a cluster in CI.
+#   ca_export — 'tctl auth export' requires authenticated access to a running auth server;
+#               teleport_export_ca_key=false is set in converge vars for this reason.
+
 - name: Verify
   hosts: all
   become: true
   gather_facts: true
 
+  vars:
+    # These defaults mirror the values set in molecule/shared/converge.yml.
+    # Override via molecule.yml extra_vars to keep verify in sync with converge.
+    molecule_teleport_node_name: "molecule-test"
+    molecule_teleport_auth_server: "localhost:3025"
+    molecule_teleport_session_recording: "node"
+
   tasks:
     # -----------------------------------------------------------------------
     # 1. Teleport binary
     # -----------------------------------------------------------------------
-    - name: Check teleport binary is in PATH (POSIX command -v)
-      ansible.builtin.shell:
-        cmd: command -v teleport
-        executable: /bin/bash
+    - name: Check teleport binary is in PATH (which)
+      ansible.builtin.command:
+        cmd: which teleport
       register: _teleport_verify_which
       changed_when: false
       failed_when: _teleport_verify_which.rc != 0
@@ -112,10 +125,10 @@
           Content: {{ _teleport_verify_conf_content }}
       when: _teleport_verify_conf_content is defined
 
-    - name: Assert config contains nodename molecule-test
+    - name: Assert config contains expected nodename
       ansible.builtin.assert:
         that:
-          - _teleport_verify_conf_content is regex('(?m)^\s+nodename:\s+["\x27]?molecule-test["\x27]?\s*$')
+          - _teleport_verify_conf_content is regex('(?m)^\s+nodename:\s+["\x27]?' ~ molecule_teleport_node_name ~ '["\x27]?\s*$')
         fail_msg: >
           Config does not contain nodename 'molecule-test'.
           Content: {{ _teleport_verify_conf_content }}
@@ -139,12 +152,12 @@
           Content: {{ _teleport_verify_conf_content }}
       when: _teleport_verify_conf_content is defined
 
-    - name: Assert config contains auth_server localhost:3025
+    - name: Assert config contains expected auth_server
       ansible.builtin.assert:
         that:
-          - _teleport_verify_conf_content is regex('(?m)^\s+auth_server:\s+["\x27]?localhost:3025["\x27]?\s*$')
+          - _teleport_verify_conf_content is regex('(?m)^\s+auth_server:\s+["\x27]?' ~ (molecule_teleport_auth_server | regex_escape) ~ '["\x27]?\s*$')
         fail_msg: >
-          Config does not contain 'auth_server: localhost:3025'.
+          Config does not contain 'auth_server: {{ molecule_teleport_auth_server }}'.
           Content: {{ _teleport_verify_conf_content }}
       when: _teleport_verify_conf_content is defined
 
@@ -176,12 +189,12 @@
           Content: {{ _teleport_verify_conf_content }}
       when: _teleport_verify_conf_content is defined
 
-    - name: Assert session_recording mode is node
+    - name: Assert session_recording mode matches expected value
       ansible.builtin.assert:
         that:
-          - _teleport_verify_conf_content is regex('(?m)^\s+mode:\s+["\x27]?node["\x27]?\s*$')
+          - _teleport_verify_conf_content is regex('(?m)^\s+mode:\s+["\x27]?' ~ molecule_teleport_session_recording ~ '["\x27]?\s*$')
         fail_msg: >
-          Config does not contain session recording mode 'node'.
+          Config does not contain session recording mode '{{ molecule_teleport_session_recording }}'.
           Content: {{ _teleport_verify_conf_content }}
       when: _teleport_verify_conf_content is defined
 
@@ -213,12 +226,16 @@
           mode={{ _teleport_verify_datadir.stat.mode }}
 
     # -----------------------------------------------------------------------
-    # 5. Systemd unit file (binary install only — all molecule scenarios use binary)
+    # 5. Systemd unit file (binary install, systemd only)
+    # NOTE: All molecule scenarios use binary install method.
+    # Unit file assertions are guarded by service_mgr to avoid failures on
+    # non-systemd platforms (runit, openrc, s6, dinit).
     # -----------------------------------------------------------------------
     - name: Stat /etc/systemd/system/teleport.service
       ansible.builtin.stat:
         path: /etc/systemd/system/teleport.service
       register: _teleport_verify_unit_stat
+      when: ansible_facts['service_mgr'] == 'systemd'
 
     - name: Assert teleport.service unit file exists
       ansible.builtin.assert:
@@ -228,6 +245,9 @@
         fail_msg: >
           /etc/systemd/system/teleport.service does not exist.
           The binary install path must deploy a systemd unit file.
+      when:
+        - ansible_facts['service_mgr'] == 'systemd'
+        - _teleport_verify_unit_stat is defined
 
     - name: Assert teleport.service unit file permissions
       ansible.builtin.assert:
@@ -236,18 +256,26 @@
         fail_msg: >
           /etc/systemd/system/teleport.service has wrong mode:
           {{ _teleport_verify_unit_stat.stat.mode }} (expected 0644)
-      when: _teleport_verify_unit_stat.stat.exists
+      when:
+        - ansible_facts['service_mgr'] == 'systemd'
+        - _teleport_verify_unit_stat is defined
+        - _teleport_verify_unit_stat.stat.exists
 
     - name: Slurp /etc/systemd/system/teleport.service
       ansible.builtin.slurp:
         src: /etc/systemd/system/teleport.service
       register: _teleport_verify_unit_raw
-      when: _teleport_verify_unit_stat.stat.exists
+      when:
+        - ansible_facts['service_mgr'] == 'systemd'
+        - _teleport_verify_unit_stat is defined
+        - _teleport_verify_unit_stat.stat.exists
 
     - name: Decode teleport unit file content
       ansible.builtin.set_fact:
         _teleport_verify_unit_content: "{{ _teleport_verify_unit_raw.content | b64decode }}"
       when:
+        - ansible_facts['service_mgr'] == 'systemd'
+        - _teleport_verify_unit_stat is defined
         - _teleport_verify_unit_stat.stat.exists
         - _teleport_verify_unit_raw.content is defined
 

--- a/wiki/roles/teleport.md
+++ b/wiki/roles/teleport.md
@@ -1,0 +1,82 @@
+# Роль: teleport
+
+**Phase**: 2 | **Направление**: Безопасность / Доступ
+
+## Цель
+
+Установка и настройка агента Teleport — платформы для zero-trust SSH-доступа с сертификатной авторизацией. Роль устанавливает `teleport`, разворачивает конфигурацию (`/etc/teleport.yaml` v3-формат) и интегрируется с ролью `ssh` через экспорт CA-ключа.
+
+## Ключевые переменные (defaults)
+
+```yaml
+teleport_enabled: true              # Включить/выключить роль
+
+# === Подсистемные переключатели (ROLE-010) ===
+teleport_manage_install: true       # Управлять установкой
+teleport_manage_config: true        # Управлять конфигурацией
+teleport_manage_service: true       # Управлять сервисом
+
+# === Обязательные ===
+teleport_auth_server: ""            # Auth/proxy адрес: "auth.example.com:443"
+teleport_join_token: ""             # Join-токен кластера
+
+# === Основные ===
+teleport_version: "17.4.10"         # Версия для binary/repo метода
+teleport_node_name: "{{ ansible_hostname }}"
+teleport_labels: {}                 # RBAC-метки узла
+teleport_session_recording: "node"  # node | proxy | off
+teleport_enhanced_recording: false  # BPF-запись (требует kernel ≥ 5.8)
+
+# === Интеграция с ssh ролью ===
+teleport_export_ca_key: true
+teleport_ca_keys_file: /etc/ssh/teleport_user_ca.pub
+
+# === Override dict (ROLE-010) ===
+teleport_config_overwrite: {}       # Произвольные ключи в teleport.yaml
+```
+
+## Что настраивает
+
+- **Установка**: пакет (Arch AUR), официальный репозиторий (Debian/RedHat), или binary с CDN (Void/Gentoo)
+- **Конфигурация**:
+  - `/var/lib/teleport/` (0750) — директория данных
+  - `/etc/teleport.yaml` (0600) — конфигурация агента (v3-формат)
+- **Systemd unit** (только binary-метод): `/etc/systemd/system/teleport.service`
+- **CA-экспорт**: при `teleport_export_ca_key: true` — записывает CA-ключ в `teleport_ca_keys_file` и устанавливает fact `ssh_teleport_integration: true` для роли `ssh`
+
+## Зависимости
+
+- `common` — отчёты `report_phase.yml` / `report_render.yml` (via `include_role`)
+- `ssh` — опциональная интеграция: `teleport` должен запускаться до `ssh` для передачи CA-факта
+
+## Tags
+
+| Tag | Что запускает | Использование |
+|-----|--------------|---------------|
+| `teleport` | Вся роль | Полное применение |
+| `teleport,install` | Только установка | Обновление бинарника без смены конфига |
+| `teleport,security` | Валидация join-токена + CA-экспорт | Обновление CA после ротации кластера |
+| `teleport,service` | Управление сервисом | Перезапуск без применения конфига |
+| `teleport,report` | Отчёты ROLE-008 | Перегенерация отчёта |
+
+## Кросс-платформенные различия
+
+| Аспект | Arch | Debian/Ubuntu | Fedora/RHEL | Void | Gentoo |
+|--------|------|---------------|-------------|------|--------|
+| Метод установки | AUR пакет | APT репо | YUM репо | binary CDN | binary CDN |
+| Пакет | `teleport-bin` | `teleport` | `teleport` | — | — |
+| Systemd unit | из пакета | из пакета | из пакета | роль деплоит | роль деплоит |
+| Конфиг | `/etc/teleport.yaml` | `/etc/teleport.yaml` | `/etc/teleport.yaml` | `/etc/teleport.yaml` | `/etc/teleport.yaml` |
+
+## Ограничения
+
+| Ограничение | Подробности |
+|-------------|-------------|
+| AUR не тестируется в CI | `teleport-bin` — AUR-пакет; molecule-сценарии используют binary-метод |
+| Сервис требует живого кластера | `teleport.service` не перейдёт в `running` без валидного `auth_server` + `join_token` |
+| CA-экспорт требует `tctl` | Экспорт CA работает только при подключённом к кластеру `tctl`; в offline/CI не выполняется |
+| BPF требует kernel ≥ 5.8 | `teleport_enhanced_recording: true` требует BTF-поддержки ядра |
+
+---
+
+Назад к [[Roadmap]]

--- a/wiki/roles/teleport.md
+++ b/wiki/roles/teleport.md
@@ -42,7 +42,7 @@ teleport_config_overwrite: {}       # Произвольные ключи в tel
   - `/var/lib/teleport/` (0750) — директория данных
   - `/etc/teleport.yaml` (0600) — конфигурация агента (v3-формат)
 - **Systemd unit** (только binary-метод): `/etc/systemd/system/teleport.service`
-- **CA-экспорт**: при `teleport_export_ca_key: true` — записывает CA-ключ в `teleport_ca_keys_file` и устанавливает fact `ssh_teleport_integration: true` для роли `ssh`
+- **CA-экспорт**: при `teleport_export_ca_key: true` — записывает CA-ключ в `teleport_ca_keys_file` и устанавливает fact `teleport_ca_deployed: true` (роль `ssh` читает его для вычисления `ssh_teleport_integration`)
 
 ## Зависимости
 


### PR DESCRIPTION
## Summary

Closes all open audit issues for the `teleport` role.

**Issues resolved by this PR:**
- #154 README-002: numbered execution flow (was checkbox list)
- #158 README-003: safety levels, internal mappings table, version fix (17.0.0→17.4.10), subsystem toggles documented
- #166 README-004–010: examples with file paths, cross-platform table, logs, troubleshooting (7 entries), testing with success criteria/verify categories/common failures, tags with use cases, file map
- #177 TEST-003: stub `converge.yml` and `verify.yml` in `default/` and `docker/` scenario dirs
- #200 TEST-012: drive `node_name`/`auth_server`/`session_recording` from vars in `verify.yml` (no more hardcoded values)
- #208 TEST-013: `systemd` unit assertions guarded by `service_mgr == systemd`; default scenario scope documented
- #212 TEST-009: split `docker/prepare.yml` into `prepare_archlinux.yml` + `prepare_debian.yml` with `include_tasks` dispatch
- #220 TEST-008: `ansible.builtin.shell` → `ansible.builtin.command` (`which teleport`)
- #234 ROLE-014/TEST-008: skipped categories comment block added at top of `verify.yml`
- #235 ROLE-007: `wiki/roles/teleport.md` created

**Issues already resolved in code (no changes needed):**
- #136 #140 #144 #178 #189 #230 — verified present in code, no changes required

## Test plan

- [ ] `molecule test -s default` passes (syntax + converge + idempotence + verify)
- [ ] `molecule test -s docker` passes on Arch + Ubuntu containers
- [ ] README sections appear in correct order per readme-requirements.md spec
- [ ] All `defaults/main.yml` variables present in README Variables table

🤖 Generated with [Claude Code](https://claude.com/claude-code)