### PR TITLE
fix(caddy): audit compliance — TEST-003/009/010/011/012, README rewrite

### DIFF
--- a/ansible/roles/caddy/README.md
+++ b/ansible/roles/caddy/README.md
@@ -1,192 +1,221 @@
 # caddy
 
-Deploys [Caddy](https://caddyserver.com/) as a Dockerized HTTPS reverse proxy for all self-hosted services.
+Dockerized HTTPS reverse proxy using [Caddy](https://caddyserver.com/), with automatic TLS (self-signed CA or Let's Encrypt) and a shared Docker network for inter-service communication.
 
-## What this role does
+## Execution flow
 
-- [x] Validates inputs and asserts supported OS (preflight)
-- [x] Creates a Docker network for inter-service communication (`caddy_docker_network`)
-- [x] Creates base directory structure (`/opt/caddy`, `sites/`, `data/`, `config/`)
-- [x] Deploys `Caddyfile` from Jinja2 template (with `admin off`, optional `local_certs`)
-- [x] Deploys `docker-compose.yml` from Jinja2 template
-- [x] Starts the Caddy container via `docker compose`
-- [x] Copies Caddy's internal root CA into the system trust store (internal TLS only, multi-distro)
-- [x] Updates system CA trust (distro-specific command)
-- [x] Configures Zen Browser to import enterprise roots (internal TLS only, best-effort)
-- [x] Verifies deployment (config files, container status, Caddyfile syntax)
-- [x] Reports execution phases via `common/report_phase.yml`
+1. **Validate** (`tasks/validate.yml`) — asserts `ansible_facts['os_family']` is in the supported list; validates `caddy_tls_email` is set when `caddy_tls_mode: acme`; fails fast on unsupported config
+2. **Load OS variables** — includes `vars/<os_family>.yml` (CA trust dir, CA cert filename, browser policy dir)
+3. **Docker network** — creates `caddy_docker_network` (`community.docker.docker_network`) when `caddy_manage_network: true`
+4. **Directories** — creates `caddy_base_dir/` (0755), `sites/` (0755), `data/` (0755), `config/` (0755)
+5. **Caddyfile** — deploys `Caddyfile` from template (0644). Includes `admin off`, `local_certs` when `tls_mode=internal`. **Triggers handler:** "Restart caddy" if changed.
+6. **docker-compose.yml** — deploys compose file from template (0644) with ports, volumes, and network. **Triggers handler:** "Restart caddy" if changed.
+7. **Start** — runs `docker compose up` via `community.docker.docker_compose_v2`.
+8. **CA trust** (when `caddy_tls_mode: internal` and `caddy_manage_certs: true`) — extracts Caddy root CA via `docker cp`, copies to OS trust store (0644), triggers `Update CA trust` handler.
+9. **Browser trust** (when `caddy_tls_mode: internal` and `caddy_manage_browser_trust: true`) — deploys `policies.json` to Zen Browser distribution directory (best-effort, skips if browser not found).
+10. **Verify** (`tasks/verify.yml`) — checks directories, Caddyfile content, docker-compose.yml content, container running state, Caddyfile syntax via `caddy validate`.
+11. **Report** — writes execution summary via `common/report_phase.yml` and `common/report_render.yml`.
 
-## Execution Flow
+### Handlers
 
-```
-validate.yml -> Network -> Directories -> Config -> Service -> CA trust -> Browser trust -> verify.yml -> Report
-```
+| Handler | Triggered by | What it does |
+|---------|-------------|--------------|
+| `restart caddy` | `Caddyfile` or `docker-compose.yml` change (steps 5–6) | Restarts Caddy via `docker_compose_v2` |
+| `update ca trust` | CA cert deployed to trust store (step 8) | Runs OS-specific `update-ca-trust` or `update-ca-certificates` |
 
-## Requirements
+## Variables
 
-- Docker daemon running on the target host
-- `community.docker` collection installed (`ansible-galaxy collection install community.docker`)
-- The `docker` role applied before this role (see Dependencies)
+### Configurable (`defaults/main.yml`)
 
-## Supported Platforms
+Override these via inventory (`group_vars/` or `host_vars/`), never edit `defaults/main.yml` directly.
 
-| Distro | OS Family | CA Trust Command |
-|--------|-----------|-----------------|
-| Arch Linux | Archlinux | `update-ca-trust` |
-| Ubuntu | Debian | `update-ca-certificates` |
-| Fedora | RedHat | `update-ca-trust` |
-| Void Linux | Void | `update-ca-certificates` |
-| Gentoo | Gentoo | `update-ca-certificates` |
+| Variable | Default | Safety | Description |
+|----------|---------|--------|-------------|
+| `caddy_enabled` | `true` | safe | Set `false` to skip the entire role |
+| `caddy_base_dir` | `"/opt/caddy"` | careful | Root directory for Caddyfile, sites, data, and config. Changing after deploy requires moving existing data volumes. |
+| `caddy_https_port` | `443` | careful | Host port mapped to container HTTPS. Changing requires firewall and DNS update. |
+| `caddy_http_port` | `80` | careful | Host port mapped to container HTTP (ACME challenge + redirect). |
+| `caddy_tls_mode` | `"internal"` | careful | `internal` = self-signed CA (no internet needed); `acme` = Let's Encrypt (requires public DNS and `caddy_tls_email`). |
+| `caddy_tls_email` | `""` | careful | Email for Let's Encrypt. Required when `caddy_tls_mode: acme`. |
+| `caddy_docker_network` | `"proxy"` | careful | Docker network shared with backend services. Must match `<role>_docker_network` in all proxied roles. |
+| `caddy_docker_image` | `"caddy:2-alpine"` | careful | Docker image. Changing triggers container restart. |
+| `caddy_manage_network` | `true` | safe | Create Docker network. Set `false` if network is managed elsewhere. |
+| `caddy_manage_certs` | `true` | careful | Copy root CA to system trust store (`internal` mode only). Disable if cert management is handled externally. |
+| `caddy_manage_browser_trust` | `true` | safe | Deploy Zen Browser enterprise root policy. No-op if Zen Browser is not installed. |
 
-## Role variables
+### Internal mappings (`vars/`)
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `caddy_enabled` | `true` | Enable/disable the entire role |
-| `caddy_base_dir` | `/opt/caddy` | Base directory for all Caddy files |
-| `caddy_https_port` | `443` | Host port mapped to container HTTPS (443) |
-| `caddy_http_port` | `80` | Host port mapped to container HTTP (80) |
-| `caddy_tls_mode` | `internal` | TLS mode: `internal` (self-signed CA) or `acme` (Let's Encrypt) |
-| `caddy_tls_email` | `""` | Email for Let's Encrypt (required when `caddy_tls_mode: acme`) |
-| `caddy_docker_network` | `proxy` | Docker network name shared with backend services |
-| `caddy_docker_image` | `caddy:2-alpine` | Docker image for Caddy container |
-| `caddy_manage_network` | `true` | Manage Docker network creation |
-| `caddy_manage_certs` | `true` | Manage CA certificate trust (internal TLS only) |
-| `caddy_manage_browser_trust` | `true` | Manage browser enterprise root trust (internal TLS only) |
+These files contain OS-specific paths. Do not override via inventory — edit directly only when adding new platform support.
 
-### TLS modes
+| File | What it contains | When to edit |
+|------|-----------------|--------------|
+| `vars/main.yml` | `_caddy_ca_cert_filename` | Rarely — only to rename the deployed cert |
+| `vars/archlinux.yml` | CA trust dir, browser policy dir, CA update command | Adding Arch-specific paths |
+| `vars/debian.yml` | CA trust dir, browser policy dir, CA update command | Adding Debian-specific paths |
+| `vars/redhat.yml` | CA trust dir, browser policy dir, CA update command | Adding RedHat-specific paths |
+| `vars/void.yml` | CA trust dir, browser policy dir, CA update command | Adding Void-specific paths |
+| `vars/gentoo.yml` | CA trust dir, browser policy dir, CA update command | Adding Gentoo-specific paths |
 
-- **`internal`** -- Caddy generates a local CA and issues self-signed certificates. The CA is copied into the system trust store (OS-specific path) and Zen Browser policy. No internet access required.
-- **`acme`** -- Caddy requests certificates from Let's Encrypt via ACME. Requires `caddy_tls_email` and public DNS pointing to the host.
+## Examples
 
-### Per-subsystem toggles
-
-Each major subsystem can be independently disabled:
-
-- `caddy_manage_network` -- skip Docker network creation (if managed elsewhere)
-- `caddy_manage_certs` -- skip CA certificate trust deployment
-- `caddy_manage_browser_trust` -- skip Zen Browser enterprise root policy
-
-## Cross-platform notes
-
-CA trust store paths and update commands are OS-specific. The role uses `vars/main.yml` mappings keyed by `ansible_facts['os_family']` to resolve the correct paths automatically.
-
-## Dependencies
-
-- `docker` -- this role must run before `caddy` (declared in `meta/main.yml`)
-
-## Example playbook
+### Internal TLS (default, self-signed CA)
 
 ```yaml
-- hosts: workstation
-  become: true
-  roles:
-    - role: docker
-    - role: caddy
-      vars:
-        caddy_tls_mode: internal
-        caddy_docker_network: proxy
+# In host_vars/server01/caddy.yml:
+caddy_tls_mode: internal
+caddy_docker_network: proxy
 ```
 
-To use ACME (Let's Encrypt):
+### ACME (Let's Encrypt)
 
 ```yaml
-- hosts: workstation
-  become: true
-  roles:
-    - role: caddy
-      vars:
-        caddy_tls_mode: acme
-        caddy_tls_email: admin@example.com
+# In host_vars/server01/caddy.yml:
+caddy_tls_mode: acme
+caddy_tls_email: admin@example.com
+caddy_https_port: 443
+caddy_http_port: 80
 ```
 
-## Tags
+### Custom ports (non-standard host)
 
-| Tag | Description |
-|-----|-------------|
-| `caddy` | All tasks |
-| `proxy` | All tasks (alias) |
-| `caddy,configure` | Directory creation, template deployment, CA trust |
-| `caddy,service` | `docker compose up` only |
-| `caddy,report` | Execution report only |
-
-## File Map
-
+```yaml
+# In host_vars/server01/caddy.yml:
+caddy_https_port: 8443
+caddy_http_port: 8080
 ```
-caddy/
-  defaults/main.yml    -- Public API: all configurable variables
-  vars/main.yml        -- Internal: OS-specific CA paths, browser policy dirs
-  tasks/
-    main.yml           -- Router: validate -> configure -> service -> verify -> report
-    validate.yml       -- Preflight: OS assert, TLS mode, email
-    verify.yml         -- Post-deploy: config check, container status, syntax
-  handlers/main.yml    -- Restart/reload via docker compose / docker exec
-  templates/
-    Caddyfile.j2       -- Global Caddy config
-    docker-compose.yml.j2 -- Container definition
-  meta/main.yml        -- Role metadata, docker dependency
-  molecule/
-    default/           -- Localhost scenario (real Docker daemon)
-    docker/            -- Arch + Ubuntu container (config-only, no daemon)
-    vagrant/           -- Arch + Ubuntu VM (full integration)
-    shared/            -- Shared converge.yml and verify.yml
+
+### Disable CA trust management
+
+```yaml
+# In host_vars/server01/caddy.yml:
+caddy_manage_certs: false
+caddy_manage_browser_trust: false
 ```
+
+### Disabling the role on a specific host
+
+```yaml
+# In host_vars/<hostname>/caddy.yml:
+caddy_enabled: false
+```
+
+## Cross-platform details
+
+| Aspect | Arch Linux | Ubuntu / Debian | Fedora / RHEL | Void Linux | Gentoo |
+|--------|-----------|-----------------|---------------|------------|--------|
+| CA trust dir | `/etc/ca-certificates/trust-source/anchors/` | `/usr/local/share/ca-certificates/` | `/etc/pki/ca-trust/source/anchors/` | `/usr/share/ca-certificates/` | `/etc/ssl/certs/` |
+| CA update cmd | `update-ca-trust` | `update-ca-certificates` | `update-ca-trust` | `update-ca-certificates` | `update-ca-certificates` |
+| Docker | from `docker` role dependency | same | same | same | same |
+| Config path | `/opt/caddy/Caddyfile` | same | same | same | same |
+| Sites path | `/opt/caddy/sites/` | same | same | same | same |
+
+## Logs
+
+### Log sources
+
+| Source | How to access | Contents |
+|--------|--------------|----------|
+| Caddy container | `docker logs caddy` | HTTP requests, TLS cert issuance, errors |
+| Caddy access log | `docker logs caddy 2>&1 \| grep -i access` | Per-request HTTP access log |
+| CA trust update | `journalctl -b \| grep -i ca` | CA certificate trust update events |
+| Docker Compose | `docker compose -f /opt/caddy/docker-compose.yml logs` | Container lifecycle events |
+
+Caddy writes structured JSON logs to stdout/stderr — captured by Docker. No file-based log rotation is configured for the container; Docker log rotation applies (configured in Docker daemon).
+
+### Reading the logs
+
+- **Check TLS cert issuance:** `docker logs caddy 2>&1 | grep -i "tls\|cert\|acme"`
+- **Check reverse proxy errors:** `docker logs caddy 2>&1 | grep -i "error\|upstream\|dial"`
+- **Check container is running:** `docker ps --filter name=caddy --filter status=running`
+- **Validate Caddyfile manually:** `docker exec caddy caddy validate --config /etc/caddy/Caddyfile`
 
 ## Troubleshooting
 
-### Caddy container not starting
-
-Check Docker logs: `docker logs caddy`. Most common cause is port conflict on 80/443.
-
-### CA certificate not trusted
-
-Verify the cert was copied: `ls -la <trust_dir>/caddy-local.crt`. Run the update command manually to check for errors.
-
-### Idempotence failures
-
-The `docker cp` command for CA extraction does not have native idempotency tracking. The role marks this as `changed_when: false` since the file content is deterministic from the container's PKI.
+| Symptom | Diagnosis | Fix |
+|---------|-----------|-----|
+| Role fails at OS assert | `ansible_facts['os_family']` not in supported list | Check `_caddy_supported_os` in defaults. Only Archlinux/Debian/RedHat/Void/Gentoo supported. |
+| Container not starting | `docker logs caddy \| tail -50` | Port 80/443 already bound, missing proxy network, or bad Caddyfile syntax. Check `docker network ls`. |
+| ACME cert fails | `docker logs caddy 2>&1 \| grep -i acme` | DNS not pointing to host, port 80 not reachable from internet, or `caddy_tls_email` missing. |
+| CA certificate not trusted by browsers | `ls -la <trust_dir>/caddy-local.crt` | Cert not copied or `update-ca-trust` failed. Delete cert and re-run role. Some browsers (Chromium) require restart. |
+| Backend service not reachable via Caddy | `docker network inspect proxy` | Service container must be on the `proxy` network. Verify `<service>_docker_network: proxy`. |
+| Idempotence failure on Caddyfile | Two consecutive runs show `changed` | Template produces non-deterministic output. Check for missing `trim_blocks` or Jinja2 whitespace issues. |
+| `caddy validate` fails inside container | `docker exec caddy caddy validate --config /etc/caddy/Caddyfile` | Invalid Caddyfile syntax after template change. Check Jinja2 rendering. |
 
 ## Testing
 
-Molecule tests live in `molecule/`. Three scenarios are provided:
+Two scenarios are required for every role. Run Docker for fast feedback, Vagrant for full validation.
 
-### `default` (localhost, no container)
+| Scenario | Command | When to use | What it tests |
+|----------|---------|-------------|---------------|
+| `default` (localhost) | `molecule test -s default` | Smoke test: after changing templates or variables | Syntax, variable loading, directories, Caddyfile rendering |
+| `docker` | `molecule test -s docker` | After changing task logic | Full converge + idempotence + verify on Arch + Ubuntu (config-only, no Docker daemon) |
+| `vagrant` | `molecule test -s vagrant` | Before releasing or after OS-specific changes | Real Docker daemon, CA trust, container lifecycle, Arch + Ubuntu |
 
-Runs against `localhost` using a local Ansible connection. Requires the actual system to have Docker installed.
+### Success criteria
 
-```bash
-cd ansible/roles/caddy
-molecule test -s default
-```
+- All steps complete: `syntax → converge → idempotence → verify → destroy`
+- Idempotence step: `changed=0` (second run changes nothing)
+- Verify step: all `ansible.builtin.assert` tasks pass with `success_msg` output
+- Final line: no `failed` tasks
 
-### `docker` (Arch + Ubuntu systemd container)
+### What the tests verify
 
-Runs inside privileged containers with systemd. Config-only verification (no Docker daemon available inside containers).
+| Category | Examples | Test requirement |
+|----------|----------|--------------------|
+| Directories | `base_dir` 0755, `sites/` 0755, `data/` 0755, `config/` 0755, owned root:root | TEST-008 |
+| Caddyfile | exists 0644, `# Ansible` managed header, `admin off`, `local_certs` (internal mode) | TEST-008 |
+| docker-compose.yml | exists 0644, correct image, port mappings, volume mounts, proxy network | TEST-008 |
+| Docker runtime | proxy network exists, container running, `caddy validate` passes, container on proxy network | TEST-008 |
+| CA trust | root CA in OS trust dir, mode 0644 (internal TLS + Docker daemon only) | TEST-008 |
+| Skip path | `caddy_enabled: false` runs without error | TEST-011 |
 
-```bash
-cd ansible/roles/caddy
-molecule test -s docker
-```
+Verification categories skipped in Docker scenario: services (managed via docker compose, not init system), packages (role deploys via Docker image). Docker checks are skipped gracefully when Docker daemon is unavailable (molecule Docker scenario).
 
-### `vagrant` (Arch + Ubuntu VM)
+### Common test failures
 
-Full integration test with real Docker daemon, CA trust, and container lifecycle.
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `UNREACHABLE — docker` | Docker daemon not running on test host | Start Docker: `systemctl start docker` |
+| `Assert base directory exists` fails | Directory creation failed (permission issue) | Check container runs as root; `become: true` is set |
+| Idempotence: `Caddyfile changed` | Template produces non-deterministic output | Check for Jinja2 whitespace or undefined variable issues |
+| `Assert caddy container is running` fails in docker scenario | Docker daemon not available in container (expected) | This assertion is guarded by `_caddy_verify_docker_info.rc == 0` — it should be skipped automatically |
+| `Assert Caddyfile contains local_certs` fails | `caddy_tls_mode` not set to `internal` in converge vars | Ensure test uses `caddy_tls_mode: internal` (the default) |
 
-```bash
-cd ansible/roles/caddy
-molecule test -s vagrant
-```
+## Tags
 
-### Shared verify playbook
+| Tag | What it runs | Use case |
+|-----|-------------|----------|
+| `caddy` | Entire role | Full apply: `ansible-playbook workstation.yml --tags caddy` |
+| `proxy` | Entire role (alias) | Same as `caddy` tag |
+| `caddy,configure` | Directories, Caddyfile, docker-compose.yml, CA trust | Redeploy config without restarting: `ansible-playbook workstation.yml --tags caddy,configure` |
+| `caddy,service` | `docker compose up` only | Restart service only: `ansible-playbook workstation.yml --tags caddy,service` |
+| `caddy,report` | Execution report only | Re-generate report: `ansible-playbook workstation.yml --tags caddy,report` |
 
-Both scenarios share `molecule/shared/verify.yml`, which asserts:
+## File map
 
-1. **Directory structure** -- `caddy_base_dir` and subdirectories exist with `root:root 0755`
-2. **Caddyfile** -- exists, `root:root 0644`, contains `Ansible` managed marker, `admin off`, correct TLS directive
-3. **docker-compose.yml** -- exists, `root:root 0644`, references correct image, port mappings, volume mounts, and proxy network
-4. **Docker daemon checks** (skipped gracefully when daemon unavailable):
-   - Proxy Docker network exists
-   - Caddy container is running
-   - `caddy validate` passes inside the container
-   - Container is connected to proxy network
-5. **CA trust** (internal TLS + Docker daemon only) -- root CA file present in OS-specific trust directory
+| File | Purpose | Edit? |
+|------|---------|-------|
+| `defaults/main.yml` | All configurable settings | No — override via inventory |
+| `vars/main.yml` | CA cert filename | Only when renaming cert |
+| `vars/<os_family>.yml` | CA trust dir, update command, browser policy dir per distro | Only when adding distro support |
+| `templates/Caddyfile.j2` | Global Caddy config template | When changing TLS or global directives |
+| `templates/docker-compose.yml.j2` | Container definition template | When changing container config |
+| `tasks/main.yml` | Execution flow orchestrator | When adding/removing phases |
+| `tasks/validate.yml` | OS and variable validation | When adding validation rules |
+| `tasks/verify.yml` | Post-deploy self-check | When changing verification logic |
+| `handlers/main.yml` | restart/reload handlers | Rarely |
+| `molecule/default/` | Localhost smoke test | When changing smoke test coverage |
+| `molecule/docker/` | Docker containerized test | When changing Docker test coverage |
+| `molecule/vagrant/` | Full VM test | When changing multi-distro coverage |
+| `molecule/shared/converge.yml` | Shared converge playbook | When changing test variables |
+| `molecule/shared/verify.yml` | Shared verify playbook | When adding verification assertions |
+| `requirements.yml` | Role dependencies (common, docker) | When adding role dependencies |
+| `meta/main.yml` | Role metadata and galaxy dependencies | Rarely |
+
+## License
+
+MIT
+
+## Author
+
+Part of the bootstrap infrastructure automation project.

--- a/ansible/roles/caddy/molecule/default/converge.yml
+++ b/ansible/roles/caddy/molecule/default/converge.yml
@@ -1,3 +1,4 @@
 ---
 # TEST-003: stub required in every scenario directory.
-- ansible.builtin.import_playbook: ../shared/converge.yml
+- name: Converge
+  ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/caddy/molecule/default/converge.yml
+++ b/ansible/roles/caddy/molecule/default/converge.yml
@@ -1,0 +1,3 @@
+---
+# TEST-003: stub required in every scenario directory.
+- ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/caddy/molecule/default/molecule.yml
+++ b/ansible/roles/caddy/molecule/default/molecule.yml
@@ -17,11 +17,8 @@ provisioner:
     host_vars:
       localhost:
         ansible_connection: local
-  playbooks:
-    converge: ../shared/converge.yml
-    verify: ../shared/verify.yml
   env:
-    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/roles"
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
 
 verifier:
   name: ansible

--- a/ansible/roles/caddy/molecule/default/verify.yml
+++ b/ansible/roles/caddy/molecule/default/verify.yml
@@ -1,0 +1,3 @@
+---
+# TEST-003: stub required in every scenario directory.
+- ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/caddy/molecule/default/verify.yml
+++ b/ansible/roles/caddy/molecule/default/verify.yml
@@ -1,3 +1,4 @@
 ---
 # TEST-003: stub required in every scenario directory.
-- ansible.builtin.import_playbook: ../shared/verify.yml
+- name: Verify
+  ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/caddy/molecule/docker/molecule.yml
+++ b/ansible/roles/caddy/molecule/docker/molecule.yml
@@ -45,7 +45,6 @@ provisioner:
   playbooks:
     prepare: prepare.yml
     converge: converge.yml
-    verify: ../shared/verify.yml
 
 verifier:
   name: ansible

--- a/ansible/roles/caddy/molecule/docker/prepare.yml
+++ b/ansible/roles/caddy/molecule/docker/prepare.yml
@@ -4,12 +4,5 @@
   become: true
   gather_facts: true
   tasks:
-    - name: Update pacman package cache
-      community.general.pacman:
-        update_cache: true
-      when: ansible_facts['os_family'] == 'Archlinux'
-
-    - name: Update apt package cache
-      ansible.builtin.apt:
-        update_cache: true
-      when: ansible_facts['os_family'] == 'Debian'
+    - name: Run OS-specific prepare tasks
+      ansible.builtin.include_tasks: "prepare_{{ ansible_facts['os_family'] | lower }}.yml"

--- a/ansible/roles/caddy/molecule/docker/prepare_archlinux.yml
+++ b/ansible/roles/caddy/molecule/docker/prepare_archlinux.yml
@@ -1,0 +1,4 @@
+---
+- name: Update pacman package cache
+  community.general.pacman:
+    update_cache: true

--- a/ansible/roles/caddy/molecule/docker/prepare_debian.yml
+++ b/ansible/roles/caddy/molecule/docker/prepare_debian.yml
@@ -1,0 +1,4 @@
+---
+- name: Update apt package cache
+  ansible.builtin.apt:
+    update_cache: true

--- a/ansible/roles/caddy/molecule/docker/verify.yml
+++ b/ansible/roles/caddy/molecule/docker/verify.yml
@@ -1,0 +1,3 @@
+---
+# TEST-003: stub required in every scenario directory.
+- ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/caddy/molecule/docker/verify.yml
+++ b/ansible/roles/caddy/molecule/docker/verify.yml
@@ -1,3 +1,4 @@
 ---
 # TEST-003: stub required in every scenario directory.
-- ansible.builtin.import_playbook: ../shared/verify.yml
+- name: Verify
+  ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/caddy/molecule/shared/converge.yml
+++ b/ansible/roles/caddy/molecule/shared/converge.yml
@@ -12,4 +12,15 @@
     docker_log_driver: "json-file"
 
   roles:
-    - role: caddy
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+
+# TEST-011: Edge case — caddy_enabled: false (skip path)
+- name: Converge — disabled role
+  hosts: all
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        caddy_enabled: false

--- a/ansible/roles/caddy/molecule/vagrant/converge.yml
+++ b/ansible/roles/caddy/molecule/vagrant/converge.yml
@@ -1,3 +1,4 @@
 ---
 # TEST-003: stub required in every scenario directory.
-- ansible.builtin.import_playbook: ../shared/converge.yml
+- name: Converge
+  ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/caddy/molecule/vagrant/converge.yml
+++ b/ansible/roles/caddy/molecule/vagrant/converge.yml
@@ -1,0 +1,3 @@
+---
+# TEST-003: stub required in every scenario directory.
+- ansible.builtin.import_playbook: ../shared/converge.yml

--- a/ansible/roles/caddy/molecule/vagrant/molecule.yml
+++ b/ansible/roles/caddy/molecule/vagrant/molecule.yml
@@ -27,8 +27,6 @@ provisioner:
       callbacks_enabled: profile_tasks
   playbooks:
     prepare: prepare.yml
-    converge: ../shared/converge.yml
-    verify: ../shared/verify.yml
 
 verifier:
   name: ansible

--- a/ansible/roles/caddy/molecule/vagrant/molecule.yml
+++ b/ansible/roles/caddy/molecule/vagrant/molecule.yml
@@ -25,6 +25,18 @@ provisioner:
   config_options:
     defaults:
       callbacks_enabled: profile_tasks
+  inventory:
+    group_vars:
+      all:
+        # CI-safe docker overrides: these apply to all plays (including TEST-011
+        # edge-case play) so the docker dependency doesn't rewrite daemon.json
+        # with incompatible defaults on the second role invocation.
+        docker_log_driver: "json-file"
+        docker_userns_remap: ""
+        docker_icc: true
+        docker_live_restore: false
+        docker_no_new_privileges: false
+        docker_storage_driver: ""
   playbooks:
     prepare: prepare.yml
 

--- a/ansible/roles/caddy/molecule/vagrant/verify.yml
+++ b/ansible/roles/caddy/molecule/vagrant/verify.yml
@@ -1,0 +1,3 @@
+---
+# TEST-003: stub required in every scenario directory.
+- ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/caddy/molecule/vagrant/verify.yml
+++ b/ansible/roles/caddy/molecule/vagrant/verify.yml
@@ -1,3 +1,4 @@
 ---
 # TEST-003: stub required in every scenario directory.
-- ansible.builtin.import_playbook: ../shared/verify.yml
+- name: Verify
+  ansible.builtin.import_playbook: ../shared/verify.yml

--- a/ansible/roles/caddy/requirements.yml
+++ b/ansible/roles/caddy/requirements.yml
@@ -1,0 +1,11 @@
+---
+# Role dependencies for caddy (TEST-010).
+# The 'common' role is used via include_role for report_phase and report_render.
+#
+# Resolution: molecule provisioner sets ANSIBLE_ROLES_PATH="${MOLECULE_PROJECT_DIRECTORY}/../"
+# so the 'common' and 'docker' roles are resolved directly from the source tree — no galaxy
+# install required. The dependency section in meta/main.yml (docker) is a local monorepo role,
+# not a public role.
+roles:
+  - name: common
+  - name: docker


### PR DESCRIPTION
## Summary

- **TEST-003** (#143): Add `converge.yml`/`verify.yml` stubs to `default`, `docker`, and `vagrant` scenarios; remove explicit `playbooks:` entries from `molecule.yml` so molecule auto-discovers stubs
- **TEST-009** (#164): Split `molecule/docker/prepare.yml` into `prepare_archlinux.yml` and `prepare_debian.yml`; dispatcher uses `include_tasks` with `os_family` key
- **TEST-010** (#148): Add `requirements.yml` declaring `common` and `docker` role dependencies
- **TEST-011** (#157): Fix `shared/converge.yml` — dynamic role name via `MOLECULE_PROJECT_DIRECTORY | basename`; add `caddy_enabled: false` edge case play
- **README** (#182, #195, #204, #213, #222, #229, #236, #243, #248, #252, #256): Complete rewrite per `readme-requirements.md` — numbered execution flow, safety levels on all variables, internal mappings table, examples with file paths, cross-platform table (5 distros), logs section, troubleshooting (7 entries), testing section with success criteria/verify categories/common failures, tags with use cases, file map table

Closes #143, #148, #157, #164, #182, #195, #204, #213, #222, #229, #236, #243, #248, #252, #256

## Test plan

- [ ] `molecule test -s docker` — syntax → converge → idempotence → verify → destroy on Arch + Ubuntu
- [ ] `molecule test -s default` — localhost smoke test
- [ ] Verify all assert tasks output `success_msg` lines in verify step
- [ ] Idempotence step reports `changed=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)