### PR TITLE
fix(git): TEST-011 — add minimal-defaults converge play for edge case testing

### DIFF
--- a/ansible/roles/git/molecule/shared/converge.yml
+++ b/ansible/roles/git/molecule/shared/converge.yml
@@ -1,13 +1,30 @@
 ---
-- name: Converge -- minimal configuration
+# TEST-011: Play 1 runs with minimal/default-equivalent vars (empty user_name,
+# no hooks, no extra config, no safe dirs) to exercise the empty-input paths.
+# Explicit vars here override any inventory host_vars set by molecule scenarios.
+- name: Converge — minimal defaults
   hosts: all
   become: true
   gather_facts: true
 
+  vars:
+    git_owner:
+      name: root
+      user_name: ""
+      user_email: ""
+      signing_method: none
+      signing_key: ""
+      credential_helper: ""
+    git_manage_hooks: false
+    git_config_extra: {}
+    git_safe_directories: []
+
   roles:
     - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
 
-- name: Converge -- full configuration
+# TEST-011: Play 2 runs with full configuration from scenario inventory vars
+# (user_name, hooks, extra config, safe dirs), exercising all subsystems.
+- name: Converge — full configuration
   hosts: all
   become: true
   gather_facts: true


### PR DESCRIPTION
## Summary

- **TEST-011** (#175): `shared/converge.yml` previously had two plays both using inventory `host_vars` (user_name="Test User", hooks=true, extra config, safe dirs). Neither play exercised the empty `user_name` or disabled subsystems code paths. The first play now explicitly overrides inventory with minimal/empty vars, exercising the `when: ... | length > 0` guards on user.name/email tasks and the disabled-subsystem branches.

Issues #147, #152, #159, #165, #188, #201, #214, #233, #242, #247, #253, #257 were already resolved in the existing codebase — verified by inspection of the relevant files.

Closes #147, #152, #159, #165, #175, #188, #201, #214, #233, #242, #247, #253, #257

## Test plan

- [ ] `molecule test -s docker` — syntax → converge → idempotence → verify → destroy on Arch + Ubuntu
- [ ] Idempotence step reports `changed=0` (minimal play should not overwrite the full play's config due to `when: length > 0` guards)
- [ ] Verify step: all assertions pass (user.name/email assertions are `when: length > 0` guarded, so they are correctly skipped after the minimal play leaves them empty, then the full play sets them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)