### PR TITLE
fix: add system update reboot boundary

### DIFF
--- a/.github/workflows/molecule-vagrant.yml
+++ b/.github/workflows/molecule-vagrant.yml
@@ -86,12 +86,15 @@ jobs:
                 | sed 's|ansible/roles/||;s|/.*||' \
                 | sort -u \
                 | while IFS= read -r role; do
-                    [ -f "ansible/roles/$role/molecule/vagrant/molecule.yml" ] && echo "$role"
+                    if [ -f "ansible/roles/$role/molecule/vagrant/molecule.yml" ]; then
+                      echo "$role"
+                    fi
                   done)
             fi
           fi
 
-          MATRIX=$(printf '%s\n' $ROLES | grep -v '^$' \
+          MATRIX=$(printf '%s\n' $ROLES \
+            | { grep -v '^$' || true; } \
             | jq -Rsc '[split("\n")[] | select(length > 0)]')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           if [ "$MATRIX" = "[]" ]; then

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -83,12 +83,15 @@ jobs:
                 | sed 's|ansible/roles/||;s|/.*||' \
                 | sort -u \
                 | while IFS= read -r role; do
-                    [ -f "ansible/roles/$role/molecule/docker/molecule.yml" ] && echo "$role"
+                    if [ -f "ansible/roles/$role/molecule/docker/molecule.yml" ]; then
+                      echo "$role"
+                    fi
                   done)
             fi
           fi
 
-          MATRIX=$(printf '%s\n' $ROLES | grep -v '^$' \
+          MATRIX=$(printf '%s\n' $ROLES \
+            | { grep -v '^$' || true; } \
             | jq -Rsc '[split("\n")[] | select(length > 0)]')
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           if [ "$MATRIX" = "[]" ]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,7 @@ tasks:
     cmds:
       - 'echo "==> Checking playbook syntax..."'
       - "{{.ANSIBLE}} playbooks/mirrors-update.yml --syntax-check"
+      - "{{.ANSIBLE}} playbooks/system_update.yml --syntax-check"
       - "{{.ANSIBLE}} playbooks/workstation.yml --syntax-check"
       - 'echo "Syntax check passed"'
 
@@ -317,6 +318,15 @@ tasks:
     cmds:
       - 'echo "==> Running playbook..."'
       - '{{.ANSIBLE}} {{.PLAYBOOK}} -v {{.CLI_ARGS}}'
+
+  system:update:
+    desc: "Update operating system packages before reboot/workstation."
+    deps: [_ensure-venv, _check-vault]
+    dir: '{{.ANSIBLE_DIR}}'
+    prompt: "This will upgrade OS packages. Reboot before running workstation. Continue?"
+    cmds:
+      - 'echo "==> Updating operating system packages..."'
+      - '{{.ANSIBLE}} playbooks/system_update.yml -v {{.CLI_ARGS}}'
 
   workstation:
     desc: "Setup full workstation. Use -- --tags 'foo,bar' to filter."

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,6 +65,7 @@ tasks:
       - task: test-vm
       - task: test-reflector
       - task: test-yay
+      - task: test-system-update
       - task: test-packages
       - task: test-user
       - task: test-ssh
@@ -179,6 +180,16 @@ tasks:
       MOLECULE_PROJECT_DIRECTORY: '{{.TASKFILE_DIR}}/{{.ANSIBLE_DIR}}'
     cmds:
       - 'echo "==> Testing yay role..."'
+      - '{{.PREFIX}} molecule test'
+
+  test-system-update:
+    desc: "Run molecule tests for system_update"
+    deps: [_ensure-venv, _check-vault]
+    dir: '{{.ANSIBLE_DIR}}/roles/system_update'
+    env:
+      MOLECULE_PROJECT_DIRECTORY: '{{.TASKFILE_DIR}}/{{.ANSIBLE_DIR}}'
+    cmds:
+      - 'echo "==> Testing system_update role..."'
       - '{{.PREFIX}} molecule test'
 
   test-packages:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -105,7 +105,7 @@ task test-<role>          # Конкретная роль
 
 ```bash
 # Выборочный запуск
-ansible-playbook playbooks/workstation.yml --tags packages
-ansible-playbook playbooks/workstation.yml --tags "docker,ssh,firewall"
-ansible-playbook playbooks/workstation.yml --skip-tags firewall
+task workstation -- --tags packages
+task workstation -- --tags "docker,ssh,firewall"
+task workstation -- --skip-tags firewall
 ```

--- a/ansible/playbooks/system_update.yml
+++ b/ansible/playbooks/system_update.yml
@@ -1,0 +1,19 @@
+---
+# Полное системное обновление ОС перед запуском workstation.
+#
+# Штатный lifecycle:
+#   task system:update
+#   reboot
+#   task workstation
+#
+# Этот playbook не устанавливает workstation package set, AUR-пакеты,
+# сервисы, desktop или dotfiles.
+
+- name: Update operating system
+  hosts: workstations
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: system_update
+      tags: [system_update, packages, upgrade]

--- a/ansible/playbooks/workstation.yml
+++ b/ansible/playbooks/workstation.yml
@@ -1,22 +1,19 @@
 ---
-# Полная настройка рабочей станции после установки ОС
+# Полная настройка рабочей станции после установки ОС.
 #
-# Использование:
-#   Через bootstrap: ./bootstrap.sh
-#   Вручную: task workstation
-#   Dry-run: task dry-run
+# Публичный запуск:
+#   task workstation
 #
-# Переопределение переменных:
-#   ansible-playbook playbooks/workstation.yml -e '{"packages_docker": ["docker", "docker-compose", "docker-buildx"]}'
+# Перед этим playbook система должна быть обновлена и перезагружена:
+#   task system:update
+#   reboot
+#   task workstation
 #
-# Выборочный запуск по тегам:
-#   ansible-playbook playbooks/workstation.yml --tags packages
-#   ansible-playbook playbooks/workstation.yml --tags "docker,firewall"
+# Dry-run:
+#   task dry-run
 #
-# Пароль sudo зашифрован в inventory/group_vars/all/vault.yml (Ansible Vault)
-# Vault bootstrap secrets resolve through .local/bootstrap/ and BOOTSTRAP_* vars
-#
-# Тип подключения определяется в inventory/hosts.ini (local или ssh)
+# Пароль sudo зашифрован в inventory/group_vars/all/vault.yml (Ansible Vault).
+# Vault bootstrap secrets resolve through .local/bootstrap/ and BOOTSTRAP_* vars.
 
 - name: Setup workstation
   hosts: workstations
@@ -28,12 +25,11 @@
     - role: reflector
       tags: [reflector, pacman, mirrors]
 
-    # --- Phase 0: Package infrastructure + full system upgrade ---
+    # --- Phase 0: Package infrastructure ---
     - role: package_manager
       tags: [packages, pacman]
 
-    # Full system upgrade + install all packages BEFORE any role that installs
-    # its own packages. Prevents Arch Linux partial upgrade breakage.
+    # Workstation package set only. Full OS upgrade belongs to system_update.
     - role: packages
       tags: [packages, install]
 

--- a/ansible/roles/chezmoi/tasks/main.yml
+++ b/ansible/roles/chezmoi/tasks/main.yml
@@ -66,6 +66,18 @@
     fail_msg: "Директория с дотфайлами не найдена: {{ chezmoi_source_dir }}"
   tags: ['chezmoi', 'dotfiles']
 
+- name: Ensure user XDG data directories are owned by target user
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ chezmoi_user }}"
+    group: "{{ chezmoi_user }}"
+    mode: '0755'
+  loop:
+    - "{{ chezmoi_user_home }}/.local"
+    - "{{ chezmoi_user_home }}/.local/share"
+  tags: ['chezmoi', 'dotfiles']
+
 # ======================================================================
 # ---- Подготовка: обои ----
 # ======================================================================
@@ -115,6 +127,8 @@
     --source {{ chezmoi_source_dir }}
     --promptChoice "Choose color theme={{ chezmoi_theme_name }}"
     --apply
+    --force
+    --no-tty
   args:
     chdir: "{{ chezmoi_user_home }}"
   register: _chezmoi_init
@@ -126,7 +140,10 @@
   become: true
   become_user: "{{ chezmoi_user }}"
   ansible.builtin.command: >-
-    {{ _chezmoi_bin }} apply --source {{ chezmoi_source_dir }}
+    {{ _chezmoi_bin }} apply
+    --force
+    --no-tty
+    --source {{ chezmoi_source_dir }}
   args:
     chdir: "{{ chezmoi_user_home }}"
   register: _chezmoi_apply

--- a/ansible/roles/package_manager/README.md
+++ b/ansible/roles/package_manager/README.md
@@ -19,6 +19,10 @@ Deploys optimized configuration via Jinja2 templates — no `lineinfile` patchin
 - [x] Runs in-role verification after deployment (verify.yml)
 - [x] Supports external pacman cache on shared storage
 
+## What this role does not do
+
+- It does not perform full OS upgrades or force `archlinux-keyring` to `latest`; that belongs to the pre-workstation `system_update` lifecycle.
+
 ## Execution flow
 
 1. **Preflight assert** (`tasks/main.yml`) — fail fast if OS family is not in `_package_manager_supported_os`
@@ -39,7 +43,7 @@ Deploys optimized configuration via Jinja2 templates — no `lineinfile` patchin
    2. Configure cache cron → `tasks/void/cache.yml` (weekly `xbps-remove -O`)
 7. **Gentoo path** (`tasks/gentoo.yml`) — stub, logs a message
 8. **In-role verification** (`tasks/verify.yml`) — slurp deployed configs, assert expected values
-9. **Handler**: `Reload systemd daemon` (guarded by `service_mgr == 'systemd'`)
+9. **Handlers**: refresh pacman sync databases after pacman config changes; reload systemd daemon where needed (guarded by `service_mgr == 'systemd'`)
 10. **Structured logging** — `report_phase` + `report_render` via common role
 
 ## Variables
@@ -235,7 +239,7 @@ molecule test -s default
 
 Example: apply only pacman config without paccache/makepkg:
 ```bash
-ansible-playbook playbooks/workstation.yml --tags pacman
+task workstation -- --tags pacman
 ```
 
 ## File map
@@ -259,7 +263,7 @@ ansible-playbook playbooks/workstation.yml --tags pacman
 | `tasks/void/cache.yml` | xbps cache cleanup cron | Changing cleanup schedule |
 | `tasks/gentoo.yml` | Gentoo stub | Implementing portage support |
 | `tasks/verify.yml` | In-role verification | Adding post-deploy checks |
-| `handlers/main.yml` | systemd daemon-reload | Adding new handlers |
+| `handlers/main.yml` | pacman sync database refresh and systemd daemon-reload | Adding new handlers |
 | `meta/main.yml` | Galaxy metadata | Changing role metadata |
 | `requirements.yml` | Role dependencies (reflector, yay) | Adding role dependencies |
 | `templates/archlinux/pacman.conf.j2` | pacman.conf template | Changing pacman config format |

--- a/ansible/roles/package_manager/handlers/main.yml
+++ b/ansible/roles/package_manager/handlers/main.yml
@@ -4,6 +4,6 @@
     daemon_reload: true
   when: ansible_facts['service_mgr'] == 'systemd'
 
-- name: Refresh pacman sync databases
+- name: Refresh pacman sync databases after pacman config change
   community.general.pacman:
     update_cache: true

--- a/ansible/roles/package_manager/tasks/archlinux.yml
+++ b/ansible/roles/package_manager/tasks/archlinux.yml
@@ -20,19 +20,6 @@
       }}
   changed_when: false
 
-- name: "Update archlinux-keyring (prevents signature verification failures)"
-  community.general.pacman:
-    name: archlinux-keyring
-    state: latest
-    update_cache: true
-  when: package_manager_pacman_cache_refresh_required | bool
-
-- name: "Verify archlinux-keyring is current without refreshing cache"
-  community.general.pacman:
-    name: archlinux-keyring
-    state: latest
-  when: not (package_manager_pacman_cache_refresh_required | bool)
-
 - name: Configure pacman
   ansible.builtin.include_tasks: archlinux/pacman.yml
 

--- a/ansible/roles/package_manager/tasks/archlinux/paccache.yml
+++ b/ansible/roles/package_manager/tasks/archlinux/paccache.yml
@@ -5,19 +5,8 @@
   community.general.pacman:
     name: pacman-contrib
     state: present
-    update_cache: true
-  when:
-    - package_manager_paccache_enabled
-    - package_manager_pacman_cache_refresh_required | bool
-  tags: ['packages', 'paccache']
-
-- name: Verify pacman-contrib is installed without refreshing cache
-  community.general.pacman:
-    name: pacman-contrib
-    state: present
-  when:
-    - package_manager_paccache_enabled
-    - not (package_manager_pacman_cache_refresh_required | bool)
+    update_cache: "{{ package_manager_pacman_cache_refresh_required | bool }}"
+  when: package_manager_paccache_enabled
   tags: ['packages', 'paccache']
 
 - name: Create paccache drop-in directory

--- a/ansible/roles/package_manager/tasks/archlinux/pacman.yml
+++ b/ansible/roles/package_manager/tasks/archlinux/pacman.yml
@@ -18,7 +18,7 @@
     mode: '0644'
     backup: true
     validate: pacman-conf --config %s
-  notify: Refresh pacman sync databases
+  notify: Refresh pacman sync databases after pacman config change
   tags: ['packages', 'pacman']
 
 - name: Setup external pacman cache

--- a/ansible/roles/packages/README.md
+++ b/ansible/roles/packages/README.md
@@ -8,7 +8,7 @@ Installs workstation packages via OS-native package managers and, on Arch Linux,
 2. **Preflight assert** — fails fast with a clear message if the OS family is not in `_packages_supported_os`; supported: Archlinux, Debian, RedHat, Void, Gentoo
 3. **Build package lists** — aggregates 16 category lists plus `packages_distro[os_family]` into `packages_all`, and builds `packages_aur_all` from `yay_packages_aur` on Arch
 4. **OS-specific install** (`tasks/install-archlinux.yml` or `tasks/install-debian.yml`)
-   - **Arch:** runs `pacman -Syu` (full upgrade, tagged `upgrade`), installs `packages_all` via `ansible.builtin.package`, then installs `packages_aur_all` via `yay` in install-only mode. Official packages always land before any AUR build.
+   - **Arch:** installs `packages_all` via `ansible.builtin.package`, then installs `packages_aur_all` via `yay` in install-only mode. Official packages always land before any AUR build.
    - **Debian/Ubuntu:** updates apt cache (`cache_valid_time: 3600`) then installs `packages_all` via `ansible.builtin.package`. Install retries up to 3 times. Skipped when `packages_all` is empty.
 5. **Verify** (`tasks/verify.yml`) — two-technique verification for every package in `packages_all + packages_aur_all`; skipped when both lists are empty:
    - **Technique 1 (runtime):** `pacman -Q <pkg>` (Arch) or `dpkg-query -W <pkg>` (Debian) — direct native package manager check
@@ -103,10 +103,10 @@ packages_base:
 
 | Aspect | Arch Linux | Debian / Ubuntu |
 |--------|-----------|-----------------|
-| Package manager | pacman (community.general.pacman for upgrade) | apt (ansible.builtin.apt for cache update) |
+| Package manager | pacman | apt (ansible.builtin.apt for cache update) |
 | Install module | `ansible.builtin.package` | `ansible.builtin.package` |
-| System upgrade | `pacman -Syu` (tagged `upgrade`) | not performed by this role |
-| Cache update | included in upgrade step | `apt update` with `cache_valid_time: 3600` |
+| System upgrade | not performed by this role | not performed by this role |
+| Cache update | handled by pre-workstation `system_update` lifecycle | `apt update` with `cache_valid_time: 3600` |
 | Package query | `pacman -Q <pkg>` | `dpkg-query -W -f='${Status}' <pkg>` |
 
 ## Logs
@@ -131,7 +131,7 @@ This role does not create log files. All output is written to Ansible stdout.
 | Package install fails with "unable to locate package" (Ubuntu) | `apt-cache search <pkg>` on host — package may need a PPA or different name | Check Ubuntu package name; some Arch packages have no direct apt equivalent |
 | AUR install fails with `yay_manage_aur_packages=true ... requires an existing yay binary` | `package_manager` or yay setup phase was skipped before running `packages` | Run `package_manager` first, or pre-provision `yay` in the scenario/play before `packages` |
 | Verify fails with "Package X not found in package facts" | `pacman -Q <pkg>` or `dpkg -l <pkg>` on host | Package manager installed it but `package_facts` module used different name format — check for epoch prefix (e.g. `1:vim`) |
-| Idempotence failure: second converge shows `changed=1` | Look for which task changed — usually `pacman -Syu` when system has pending updates | Add `--skip-tags upgrade` to molecule options; the upgrade step is intentionally non-idempotent when updates are available |
+| Idempotence failure: second converge shows `changed=1` | Look for which package task changed | Fix the non-idempotent install/AUR task; full OS upgrade belongs to `system_update`, not this role |
 | Role skips silently with no output | Check `packages_enabled` in host/group vars — may be `false` | Set `packages_enabled: true` or remove the override |
 
 ## Testing
@@ -146,7 +146,7 @@ Both scenarios required. Run Docker for fast feedback; Vagrant for cross-platfor
 ### Success criteria
 
 - All steps complete: `syntax → create → prepare → converge → idempotence → verify → destroy`
-- Idempotence step: `changed=0` (second run changes nothing — upgrade is skipped via `--skip-tags upgrade`)
+- Idempotence step: `changed=0` (second run changes nothing)
 - Verify step: all assert tasks pass; final line shows `packages verify passed`
 - No `FAILED` tasks in output
 
@@ -165,7 +165,7 @@ Both scenarios required. Run Docker for fast feedback; Vagrant for cross-platfor
 |-------|-------|-----|
 | `target not found: <pkg>` (Arch) | Package name doesn't exist in pacman repos | Check exact name: `pacman -Ss <pkg>` |
 | `Unable to locate package <pkg>` (Ubuntu) | Package not in apt repos | Check Ubuntu name: `apt-cache search <pkg>` |
-| `idempotence: changed=1` on upgrade | Arch has pending updates between converge runs | Molecule uses `--skip-tags upgrade`; if still failing, check which task changed |
+| `idempotence: changed=1` | Package install or AUR task is not idempotent | Check which task changed and fix state detection |
 | `Package X not found in package facts` | `package_facts` module uses different name format | Known for packages with epoch prefix; investigate with `pacman -Qi <pkg>` |
 | `Assertion failed: OS family not supported` | Molecule platform uses unexpected os_family | Check image: `ansible -m setup localhost \| grep os_family` |
 | Vagrant: `Python not found` | Bootstrap in prepare.yml skipped | Run full sequence: `molecule test -s vagrant`, not just `converge` |
@@ -177,15 +177,14 @@ Both scenarios required. Run Docker for fast feedback; Vagrant for cross-platfor
 | `packages` | Entire role | Full apply |
 | `packages,install` | Build list + install step only | Re-install packages without re-running verify or report |
 | `aur` | Arch AUR install path inside `packages` | Skip or target only the yay-backed portion |
-| `packages,install,upgrade` | System upgrade + install (Arch only) | Force full upgrade |
 | `report` | Report tasks only | Re-generate execution report |
 
 ```bash
 # Run only the install phase (skip report and verify)
 ansible-playbook site.yml --tags packages,install --skip-tags report
 
-# Skip system upgrade (install only new packages, no pacman -Syu)
-ansible-playbook site.yml --tags packages --skip-tags upgrade,report
+# Run package installation without report output
+ansible-playbook site.yml --tags packages --skip-tags report
 ```
 
 ## File map
@@ -194,14 +193,9 @@ ansible-playbook site.yml --tags packages --skip-tags upgrade,report
 |------|---------|-------|
 | `defaults/main.yml` | All configurable settings and supported OS list | No — override via inventory |
 | `tasks/main.yml` | Execution orchestrator: preflight → build list → install → verify → report | When adding/removing steps |
-| `tasks/install-archlinux.yml` | Arch-specific: system upgrade + package install | When changing Arch install behavior |
+| `tasks/install-archlinux.yml` | Arch-specific package install | When changing Arch install behavior |
 | `tasks/install-debian.yml` | Debian/Ubuntu-specific: cache update + package install | When changing Debian install behavior |
 | `tasks/verify.yml` | In-role post-install verification: native PM command + package_facts assert | When changing verification logic |
-| `vars/archlinux.yml` | Arch Linux OS-family vars stub (package manager specifics) | When adding Arch-specific variables |
-| `vars/debian.yml` | Debian/Ubuntu OS-family vars stub (package manager specifics) | When adding Debian-specific variables |
-| `vars/redhat.yml` | RedHat/Fedora OS-family vars stub (no install task yet) | When implementing RedHat support |
-| `vars/void.yml` | Void Linux OS-family vars stub (no install task yet) | When implementing Void support |
-| `vars/gentoo.yml` | Gentoo OS-family vars stub (no install task yet) | When implementing Gentoo support |
 | `meta/main.yml` | Role metadata and galaxy info | When updating supported platforms |
 | `molecule/docker/` | Docker CI scenario (Arch + Ubuntu + empty-list edge cases) | When changing CI test coverage |
 | `molecule/vagrant/` | Vagrant cross-platform scenario (Arch VM + Ubuntu VM) | When changing full-system test coverage |

--- a/ansible/roles/packages/defaults/main.yml
+++ b/ansible/roles/packages/defaults/main.yml
@@ -33,11 +33,6 @@ packages_theming: []    # GTK/Qt themes and icon packs
 packages_search: []     # Search utilities (fzf, ripgrep)
 packages_viewers: []    # File viewers (bat, jq)
 
-# Reuse the same package databases for rapid repeat/idempotency runs.
-# A fresh sync is still forced whenever the local pacman DBs are older than
-# this threshold or missing entirely.
-packages_pacman_cache_valid_time: 3600
-
 # Third-party release mirrors are an explicit operator decision, not a default.
 # Leave false unless you intentionally want the AUR transport proxy workaround.
 packages_aur_transport_proxy_enabled: false

--- a/ansible/roles/packages/tasks/install-archlinux.yml
+++ b/ansible/roles/packages/tasks/install-archlinux.yml
@@ -1,55 +1,4 @@
 ---
-- name: Find pacman sync databases
-  ansible.builtin.find:
-    paths: /var/lib/pacman/sync
-    patterns: "*.db"
-    file_type: file
-  register: _packages_pacman_sync_db
-  tags: ['packages', 'install', 'upgrade']
-
-- name: Decide whether pacman cache refresh is required
-  ansible.builtin.set_fact:
-    _packages_pacman_cache_refresh_required: >-
-      {{
-        (_packages_pacman_sync_db.matched | default(0) | int) == 0 or
-        (
-          ansible_facts['date_time']['epoch'] | int -
-          ((_packages_pacman_sync_db.files | map(attribute='mtime') | max | default(0)) | int)
-        ) >= (packages_pacman_cache_valid_time | int)
-      }}
-  changed_when: false
-  tags: ['packages', 'install', 'upgrade']
-
-# Arch Linux: full system upgrade then install official packages.
-#
-# upgrade: true is REQUIRED on Arch Linux rolling release.
-# Without it, installing new packages onto an old snapshot causes "conflicting
-# files" errors when upstream does package splits (e.g. gcc-libs → libgcc +
-# libstdc++ + libgomp). There is no safe partial-upgrade path on Arch.
-#
-# First-run duration is proportional to how old the initial snapshot is.
-# Keep the snapshot up-to-date (monthly) to minimize upgrade time.
-- name: "Full system upgrade (pacman -Syu)"
-  community.general.pacman:
-    update_cache: true
-    upgrade: true
-  retries: 3
-  delay: 5
-  register: _packages_upgrade_result
-  until: _packages_upgrade_result is succeeded
-  when: _packages_pacman_cache_refresh_required | bool
-  tags: ['packages', 'install', 'upgrade']
-
-- name: "Full system upgrade (pacman -Su)"
-  community.general.pacman:
-    upgrade: true
-  retries: 3
-  delay: 5
-  register: _packages_upgrade_result
-  until: _packages_upgrade_result is succeeded
-  when: not (_packages_pacman_cache_refresh_required | bool)
-  tags: ['packages', 'install', 'upgrade']
-
 - name: Install packages (pacman)
   ansible.builtin.package:
     name: "{{ packages_all }}"
@@ -58,7 +7,8 @@
   delay: 5
   register: _packages_install_result
   until: _packages_install_result is succeeded
-  when: packages_all | length > 0
+  when:
+    - packages_all | length > 0
   tags: ['packages', 'install']
 
 - name: Set up AUR helper (yay)
@@ -72,7 +22,8 @@
   vars:
     yay_manage_setup: true
     yay_manage_aur_packages: false
-  when: packages_aur_all | length > 0
+  when:
+    - packages_aur_all | length > 0
   tags: ['packages', 'install', 'aur']
 
 - name: Apply AUR transport proxy workaround layer
@@ -101,5 +52,6 @@
     yay_manage_aur_packages: true
     yay_packages_aur: "{{ packages_aur_all }}"
     yay_packages_official: "{{ packages_all }}"
-  when: packages_aur_all | length > 0
+  when:
+    - packages_aur_all | length > 0
   tags: ['packages', 'install', 'aur']

--- a/ansible/roles/packages/tasks/install-debian.yml
+++ b/ansible/roles/packages/tasks/install-debian.yml
@@ -16,5 +16,6 @@
   delay: 5
   register: _packages_install_result
   until: _packages_install_result is succeeded
-  when: packages_all | length > 0
+  when:
+    - packages_all | length > 0
   tags: ['packages', 'install']

--- a/ansible/roles/packages/tasks/main.yml
+++ b/ansible/roles/packages/tasks/main.yml
@@ -53,7 +53,8 @@
 
     - name: Build combined verification package list
       ansible.builtin.set_fact:
-        packages_verify_all: "{{ packages_all + packages_aur_all }}"
+        packages_verify_all: >-
+          {{ packages_all + packages_aur_all }}
       tags: ['packages']
 
     # ---- OS-specific package installation ----

--- a/ansible/roles/packages/vars/archlinux.yml
+++ b/ansible/roles/packages/vars/archlinux.yml
@@ -1,7 +1,0 @@
----
-# Arch Linux — package manager specifics
-# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
-# OS-specific install logic is in tasks/install-archlinux.yml.
-#
-# Arch uses community.general.pacman for the system upgrade step (upgrade: true has no
-# equivalent in ansible.builtin.package) and ansible.builtin.package for installation.

--- a/ansible/roles/packages/vars/debian.yml
+++ b/ansible/roles/packages/vars/debian.yml
@@ -1,7 +1,0 @@
----
-# Debian/Ubuntu — package manager specifics
-# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
-# OS-specific install logic is in tasks/install-debian.yml.
-#
-# Debian uses ansible.builtin.apt for cache update (cache_valid_time has no equivalent in
-# ansible.builtin.package) and ansible.builtin.package for installation.

--- a/ansible/roles/packages/vars/gentoo.yml
+++ b/ansible/roles/packages/vars/gentoo.yml
@@ -1,6 +1,0 @@
----
-# Gentoo — package manager specifics
-# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
-#
-# No install task implemented yet (stub). Add tasks/install-gentoo.yml when Gentoo support
-# is required. Package manager: emerge.

--- a/ansible/roles/packages/vars/redhat.yml
+++ b/ansible/roles/packages/vars/redhat.yml
@@ -1,6 +1,0 @@
----
-# RedHat/Fedora — package manager specifics
-# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
-#
-# No install task implemented yet (stub). Add tasks/install-redhat.yml when RedHat support
-# is required. Package manager: dnf.

--- a/ansible/roles/packages/vars/void.yml
+++ b/ansible/roles/packages/vars/void.yml
@@ -1,6 +1,0 @@
----
-# Void Linux — package manager specifics
-# All package lists (packages_base, packages_editors, etc.) are user-supplied via inventory.
-#
-# No install task implemented yet (stub). Add tasks/install-void.yml when Void support
-# is required. Package manager: xbps-install.

--- a/ansible/roles/system_update/README.md
+++ b/ansible/roles/system_update/README.md
@@ -1,0 +1,31 @@
+# system_update
+
+Performs a full operating-system package upgrade before workstation configuration.
+
+## Contract
+
+- `system_update` updates the installed OS only.
+- It does not install the workstation package set.
+- It does not install AUR packages.
+- It does not configure services, users, desktop, Docker, VM integration, or dotfiles.
+- A reboot boundary is required after a successful run and before `task workstation`.
+
+## Workflow
+
+```bash
+task system:update
+reboot
+task workstation
+```
+
+## Backends
+
+| OS family | Status | Backend |
+|-----------|--------|---------|
+| Archlinux | implemented | `pacman -Sy` → `archlinux-keyring` → `pacman -Su` |
+| Debian | blocked | fail-fast diagnostic |
+| RedHat | blocked | fail-fast diagnostic |
+| Void | blocked | fail-fast diagnostic |
+| Gentoo | blocked | fail-fast diagnostic |
+
+The non-Arch backends are explicit blockers in this slice. They must not silently skip.

--- a/ansible/roles/system_update/defaults/main.yml
+++ b/ansible/roles/system_update/defaults/main.yml
@@ -1,0 +1,18 @@
+---
+# Enable/disable the system_update role.
+system_update_enabled: true
+
+# Supported OS families for the project.
+_system_update_supported_os:
+  - Archlinux
+  - Debian
+  - RedHat
+  - Void
+  - Gentoo
+
+# Retry policy for transient package mirror/network failures.
+system_update_retries: 3
+system_update_retry_delay: 5
+
+# Non-Arch backends are intentionally blocked until implemented explicitly.
+system_update_fail_unimplemented_backends: true

--- a/ansible/roles/system_update/meta/main.yml
+++ b/ansible/roles/system_update/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: system_update
+  author: textyre
+  description: Full operating-system package upgrade before workstation configuration
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: ArchLinux
+      versions: [all]
+    - name: Debian
+      versions: [all]
+    - name: Fedora
+      versions: [all]
+    - name: Void Linux
+      versions: [all]
+    - name: Gentoo
+      versions: [all]
+  galaxy_tags: [systemupdate, upgrade, packages]
+dependencies: []

--- a/ansible/roles/system_update/molecule/default/molecule.yml
+++ b/ansible/roles/system_update/molecule/default/molecule.yml
@@ -1,0 +1,37 @@
+---
+# Safe contract-only scenario. It validates source/playbook boundaries without
+# running a full OS upgrade on the caller's local machine.
+driver:
+  name: default
+  options:
+    managed: false
+
+platforms:
+  - name: localhost
+
+provisioner:
+  name: ansible
+  options:
+    extra-vars: "system_update_test_live=false system_update_test_verify_reboot_boundary=false"
+  config_options:
+    defaults:
+      callbacks_enabled: profile_tasks
+  inventory:
+    host_vars:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    converge: ../shared/converge.yml
+    verify: ../shared/verify.yml
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - syntax
+    - converge
+    - idempotence
+    - verify

--- a/ansible/roles/system_update/molecule/docker/molecule.yml
+++ b/ansible/roles/system_update/molecule/docker/molecule.yml
@@ -1,0 +1,61 @@
+---
+driver:
+  name: docker
+
+platforms:
+  - name: Archlinux-systemd
+    image: "${MOLECULE_ARCH_IMAGE:-ghcr.io/textyre/arch-base:latest}"
+    pre_build_image: true
+    command: /usr/lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
+  - name: Ubuntu-systemd
+    image: "${MOLECULE_UBUNTU_IMAGE:-ghcr.io/textyre/ubuntu-base:latest}"
+    pre_build_image: true
+    command: /lib/systemd/systemd
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    tmpfs:
+      - /run
+      - /tmp
+    privileged: true
+    dns_servers:
+      - 8.8.8.8
+      - 8.8.4.4
+
+provisioner:
+  name: ansible
+  options:
+    extra-vars: "system_update_test_live=true system_update_test_verify_reboot_boundary=false"
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+  config_options:
+    defaults:
+      callbacks_enabled: profile_tasks
+  playbooks:
+    prepare: prepare.yml
+    converge: ../shared/converge.yml
+    verify: ../shared/verify.yml
+
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/ansible/roles/system_update/molecule/docker/prepare.yml
+++ b/ansible/roles/system_update/molecule/docker/prepare.yml
@@ -1,0 +1,3 @@
+---
+- name: Bootstrap Docker container
+  ansible.builtin.import_playbook: ../../../../molecule/shared/prepare-docker.yml

--- a/ansible/roles/system_update/molecule/shared/converge.yml
+++ b/ansible/roles/system_update/molecule/shared/converge.yml
@@ -1,0 +1,177 @@
+---
+- name: Validate system_update source contract
+  hosts: localhost
+  gather_facts: false
+  vars:
+    _system_update_test_project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+    _system_update_test_role_dir: >-
+      {{
+        _system_update_test_project_dir
+        if (_system_update_test_project_dir | basename) == 'system_update'
+        else _system_update_test_project_dir ~ '/roles/system_update'
+      }}
+  tasks:
+    - name: Read Arch backend source
+      ansible.builtin.set_fact:
+        _system_update_test_arch_source: >-
+          {{ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/archlinux.yml') }}
+
+    - name: Read role task sources
+      ansible.builtin.set_fact:
+        _system_update_test_task_sources: >-
+          {{
+            lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/main.yml')
+            ~ '\n'
+            ~ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/archlinux.yml')
+            ~ '\n'
+            ~ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/debian.yml')
+            ~ '\n'
+            ~ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/redhat.yml')
+            ~ '\n'
+            ~ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/void.yml')
+            ~ '\n'
+            ~ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/tasks/gentoo.yml')
+          }}
+
+    - name: Assert Arch backend update order
+      ansible.builtin.assert:
+        that:
+          - "'Refresh package databases (pacman -Sy)' in _system_update_test_arch_source"
+          - "'Update archlinux-keyring before full upgrade' in _system_update_test_arch_source"
+          - "'Full system upgrade (pacman -Su)' in _system_update_test_arch_source"
+          - _system_update_test_arch_source.find('Refresh package databases (pacman -Sy)') < _system_update_test_arch_source.find('Update archlinux-keyring before full upgrade')
+          - _system_update_test_arch_source.find('Update archlinux-keyring before full upgrade') < _system_update_test_arch_source.find('Full system upgrade (pacman -Su)')
+          - "'upgrade: true' in _system_update_test_arch_source"
+        fail_msg: "Arch backend must run pacman cache refresh, keyring update, then full system upgrade."
+        success_msg: "Arch backend order is pacman -Sy -> archlinux-keyring -> pacman -Su."
+
+    - name: Assert role stays inside update-only boundary
+      ansible.builtin.assert:
+        that:
+          - "'ansible.builtin.reboot' not in _system_update_test_task_sources"
+          - "'role: workstation' not in _system_update_test_task_sources"
+          - "'role: docker' not in _system_update_test_task_sources"
+          - "'kewlfft.aur' not in _system_update_test_task_sources"
+          - "'yay' not in _system_update_test_task_sources"
+        fail_msg: "system_update must not reboot or run workstation/downstream package responsibilities."
+        success_msg: "system_update source is limited to OS update and explicit backend diagnostics."
+
+- name: Converge system_update live backend contract
+  hosts: all
+  gather_facts: false
+  vars:
+    _system_update_test_project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+    _system_update_test_role_name: >-
+      {{
+        lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename
+        if (_system_update_test_project_dir | basename) == 'system_update'
+        else 'system_update'
+      }}
+    _system_update_test_live_enabled: "{{ system_update_test_live | default(false) | bool }}"
+  tasks:
+    - name: Skip live converge when scenario is contract-only
+      ansible.builtin.meta: end_host
+      when: not _system_update_test_live_enabled
+
+    - name: Gather live backend facts
+      ansible.builtin.setup:
+
+    - name: Exercise Arch system update backend
+      become: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Capture boot id before system_update
+          ansible.builtin.command:
+            cmd: cat /proc/sys/kernel/random/boot_id
+          register: _system_update_test_boot_id_before
+          changed_when: false
+          failed_when: _system_update_test_boot_id_before.rc != 0
+
+        - name: Capture running kernel before system_update
+          ansible.builtin.command:
+            cmd: uname -r
+          register: _system_update_test_uname_before
+          changed_when: false
+          failed_when: _system_update_test_uname_before.rc != 0
+
+        - name: Apply system_update role on Arch
+          ansible.builtin.include_role:
+            name: "{{ _system_update_test_role_name }}"
+
+        - name: Capture boot id after system_update before reboot
+          ansible.builtin.command:
+            cmd: cat /proc/sys/kernel/random/boot_id
+          register: _system_update_test_boot_id_after_update
+          changed_when: false
+          failed_when: _system_update_test_boot_id_after_update.rc != 0
+
+        - name: Capture running kernel after system_update before reboot
+          ansible.builtin.command:
+            cmd: uname -r
+          register: _system_update_test_uname_after_update
+          changed_when: false
+          failed_when: _system_update_test_uname_after_update.rc != 0
+
+        - name: Assert system_update did not reboot by itself
+          ansible.builtin.assert:
+            that:
+              - _system_update_test_boot_id_after_update.stdout | trim == _system_update_test_boot_id_before.stdout | trim
+            fail_msg: >-
+              system_update changed boot_id during the role run. Reboot must remain
+              an external workflow boundary, not role-internal behavior.
+            success_msg: "system_update completed without rebooting the host."
+
+        - name: Persist Arch pre-reboot facts for verify phase
+          ansible.builtin.copy:
+            dest: /tmp/system_update_molecule_pre_reboot.json
+            owner: root
+            group: root
+            mode: "0600"
+            content: |
+              {{
+                {
+                  'boot_id_before': _system_update_test_boot_id_before.stdout | trim,
+                  'boot_id_after_update': _system_update_test_boot_id_after_update.stdout | trim,
+                  'uname_before': _system_update_test_uname_before.stdout | trim,
+                  'uname_after_update': _system_update_test_uname_after_update.stdout | trim
+                } | to_nice_json
+              }}
+
+    - name: Exercise non-Arch fail-fast backend contract
+      become: true
+      when: ansible_facts['os_family'] != 'Archlinux'
+      block:
+        - name: Apply system_update role and expect backend diagnostic failure
+          ansible.builtin.include_role:
+            name: "{{ _system_update_test_role_name }}"
+
+        - name: Fail if unimplemented backend did not stop execution
+          ansible.builtin.fail:
+            msg: >-
+              system_update unexpectedly succeeded on {{ ansible_facts['os_family'] }}.
+              Non-Arch backends must fail fast until implemented explicitly.
+
+      rescue:
+        - name: Persist expected backend failure for verify phase
+          ansible.builtin.copy:
+            dest: /tmp/system_update_molecule_expected_backend_failure.json
+            owner: root
+            group: root
+            mode: "0600"
+            content: |
+              {{
+                {
+                  'os_family': ansible_facts['os_family'],
+                  'message': ansible_failed_result.msg | default(ansible_failed_result.message | default(''))
+                } | to_nice_json
+              }}
+
+        - name: Assert backend failure message is explicit
+          ansible.builtin.assert:
+            that:
+              - "'system_update backend' in (ansible_failed_result.msg | default(ansible_failed_result.message | default('')))"
+              - "'not implemented' in (ansible_failed_result.msg | default(ansible_failed_result.message | default('')))"
+            fail_msg: >-
+              Non-Arch backend failed, but not with the expected explicit diagnostic:
+              {{ ansible_failed_result.msg | default(ansible_failed_result.message | default(ansible_failed_result)) }}
+            success_msg: "Non-Arch backend failed fast with explicit implementation diagnostic."

--- a/ansible/roles/system_update/molecule/shared/verify.yml
+++ b/ansible/roles/system_update/molecule/shared/verify.yml
@@ -1,0 +1,164 @@
+---
+- name: Verify system_update source contract
+  hosts: localhost
+  gather_facts: false
+  vars:
+    _system_update_test_project_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}"
+    _system_update_test_role_dir: >-
+      {{
+        _system_update_test_project_dir
+        if (_system_update_test_project_dir | basename) == 'system_update'
+        else _system_update_test_project_dir ~ '/roles/system_update'
+      }}
+  tasks:
+    - name: Read system_update playbook source
+      ansible.builtin.set_fact:
+        _system_update_test_playbook_source: >-
+          {{ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/../../playbooks/system_update.yml') }}
+
+    - name: Read workstation playbook source
+      ansible.builtin.set_fact:
+        _system_update_test_workstation_source: >-
+          {{ lookup('ansible.builtin.file', _system_update_test_role_dir ~ '/../../playbooks/workstation.yml') }}
+
+    - name: Assert playbook boundary contract
+      ansible.builtin.assert:
+        that:
+          - "'role: system_update' in _system_update_test_playbook_source"
+          - "'role: packages' not in _system_update_test_playbook_source"
+          - "'role: docker' not in _system_update_test_playbook_source"
+          - "'role: vm' not in _system_update_test_playbook_source"
+          - "'role: system_update' not in _system_update_test_workstation_source"
+        fail_msg: "system_update playbook must be separate from workstation/downstream roles."
+        success_msg: "system_update playbook is isolated from workstation configuration roles."
+
+- name: Verify system_update live backend and reboot boundary
+  hosts: all
+  gather_facts: false
+  vars:
+    _system_update_test_live_enabled: "{{ system_update_test_live | default(false) | bool }}"
+    _system_update_test_reboot_enabled: "{{ system_update_test_verify_reboot_boundary | default(false) | bool }}"
+  tasks:
+    - name: Skip live verify when scenario is contract-only
+      ansible.builtin.meta: end_host
+      when: not _system_update_test_live_enabled
+
+    - name: Gather live verify facts
+      ansible.builtin.setup:
+
+    - name: Verify Arch backend and reboot boundary
+      become: true
+      when: ansible_facts['os_family'] == 'Archlinux'
+      block:
+        - name: Read persisted Arch pre-reboot facts
+          ansible.builtin.slurp:
+            src: /tmp/system_update_molecule_pre_reboot.json
+          register: _system_update_verify_pre_reboot_raw
+
+        - name: Decode Arch pre-reboot facts
+          ansible.builtin.set_fact:
+            _system_update_verify_pre_reboot: "{{ _system_update_verify_pre_reboot_raw.content | b64decode | from_json }}"
+
+        - name: Capture boot id before verify reboot
+          ansible.builtin.command:
+            cmd: cat /proc/sys/kernel/random/boot_id
+          register: _system_update_verify_boot_id_before_reboot
+          changed_when: false
+          failed_when: _system_update_verify_boot_id_before_reboot.rc != 0
+
+        - name: Assert role left reboot as external boundary
+          ansible.builtin.assert:
+            that:
+              - _system_update_verify_pre_reboot.boot_id_before == _system_update_verify_pre_reboot.boot_id_after_update
+              - _system_update_verify_boot_id_before_reboot.stdout | trim == _system_update_verify_pre_reboot.boot_id_after_update
+            fail_msg: >-
+              Boot id changed before the workflow reboot boundary.
+              facts={{ _system_update_verify_pre_reboot }},
+              current={{ _system_update_verify_boot_id_before_reboot.stdout | trim }}
+            success_msg: "Pre-reboot facts prove system_update did not reboot internally."
+
+        - name: Reboot Arch host for workflow boundary verification
+          ansible.builtin.reboot:
+            reboot_timeout: 900
+            connect_timeout: 20
+            test_command: whoami
+          when: _system_update_test_reboot_enabled
+
+        - name: Capture boot id after workflow reboot
+          ansible.builtin.command:
+            cmd: cat /proc/sys/kernel/random/boot_id
+          register: _system_update_verify_boot_id_after_reboot
+          changed_when: false
+          failed_when: _system_update_verify_boot_id_after_reboot.rc != 0
+          when: _system_update_test_reboot_enabled
+
+        - name: Capture running kernel after workflow reboot
+          ansible.builtin.command:
+            cmd: uname -r
+          register: _system_update_verify_uname_after_reboot
+          changed_when: false
+          failed_when: _system_update_verify_uname_after_reboot.rc != 0
+          when: _system_update_test_reboot_enabled
+
+        - name: Check /usr/lib module tree after workflow reboot
+          ansible.builtin.stat:
+            path: "/usr/lib/modules/{{ _system_update_verify_uname_after_reboot.stdout | trim }}"
+          register: _system_update_verify_usr_modules
+          when: _system_update_test_reboot_enabled
+
+        - name: Check /lib module tree after workflow reboot
+          ansible.builtin.stat:
+            path: "/lib/modules/{{ _system_update_verify_uname_after_reboot.stdout | trim }}"
+          register: _system_update_verify_lib_modules
+          when: _system_update_test_reboot_enabled
+
+        - name: Assert workflow reboot changed boot and restored matching module tree
+          ansible.builtin.assert:
+            that:
+              - _system_update_verify_boot_id_after_reboot.stdout | trim != _system_update_verify_pre_reboot.boot_id_after_update
+              - _system_update_verify_usr_modules.stat.exists or _system_update_verify_lib_modules.stat.exists
+            fail_msg: >-
+              Reboot boundary did not produce a fresh boot with matching modules.
+              before={{ _system_update_verify_pre_reboot }},
+              after_boot_id={{ _system_update_verify_boot_id_after_reboot.stdout | trim }},
+              uname={{ _system_update_verify_uname_after_reboot.stdout | trim }},
+              usr_modules={{ _system_update_verify_usr_modules.stat.exists | default(false) }},
+              lib_modules={{ _system_update_verify_lib_modules.stat.exists | default(false) }}
+            success_msg: >-
+              Reboot boundary verified:
+              boot_id {{ _system_update_verify_pre_reboot.boot_id_after_update }}
+              -> {{ _system_update_verify_boot_id_after_reboot.stdout | trim }},
+              uname={{ _system_update_verify_uname_after_reboot.stdout | trim }}.
+          when: _system_update_test_reboot_enabled
+
+        - name: Report Docker/no-reboot boundary verification
+          ansible.builtin.debug:
+            msg: >-
+              system_update live backend verified without performing reboot in this scenario.
+              Reboot boundary is exercised by the vagrant scenario.
+          when: not _system_update_test_reboot_enabled
+
+    - name: Verify non-Arch backend fail-fast contract
+      become: true
+      when: ansible_facts['os_family'] != 'Archlinux'
+      block:
+        - name: Read expected backend failure file
+          ansible.builtin.slurp:
+            src: /tmp/system_update_molecule_expected_backend_failure.json
+          register: _system_update_verify_backend_failure_raw
+
+        - name: Decode expected backend failure file
+          ansible.builtin.set_fact:
+            _system_update_verify_backend_failure: "{{ _system_update_verify_backend_failure_raw.content | b64decode | from_json }}"
+
+        - name: Assert backend failure contract
+          ansible.builtin.assert:
+            that:
+              - _system_update_verify_backend_failure.os_family == ansible_facts['os_family']
+              - "'system_update backend' in _system_update_verify_backend_failure.message"
+              - "'not implemented' in _system_update_verify_backend_failure.message"
+            fail_msg: >-
+              Expected explicit non-Arch backend failure was not captured:
+              {{ _system_update_verify_backend_failure }}
+            success_msg: >-
+              {{ ansible_facts['os_family'] }} backend fail-fast diagnostic verified.

--- a/ansible/roles/system_update/molecule/vagrant/molecule.yml
+++ b/ansible/roles/system_update/molecule/vagrant/molecule.yml
@@ -1,0 +1,44 @@
+---
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+
+platforms:
+  - name: arch-vm
+    box: arch-base
+    box_url: https://github.com/textyre/arch-images/releases/latest/download/arch-base.box
+    memory: 2048
+    cpus: 2
+  - name: ubuntu-base
+    box: ubuntu-base
+    box_url: https://github.com/textyre/ubuntu-images/releases/latest/download/ubuntu-base.box
+    memory: 2048
+    cpus: 2
+
+provisioner:
+  name: ansible
+  options:
+    extra-vars: "system_update_test_live=true system_update_test_verify_reboot_boundary=true"
+  config_options:
+    defaults:
+      callbacks_enabled: profile_tasks
+  env:
+    ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/../"
+  playbooks:
+    prepare: prepare.yml
+    converge: ../shared/converge.yml
+    verify: ../shared/verify.yml
+
+verifier:
+  name: ansible
+
+scenario:
+  test_sequence:
+    - syntax
+    - create
+    - prepare
+    - converge
+    - idempotence
+    - verify
+    - destroy

--- a/ansible/roles/system_update/molecule/vagrant/prepare.yml
+++ b/ansible/roles/system_update/molecule/vagrant/prepare.yml
@@ -1,0 +1,3 @@
+---
+- name: Bootstrap Vagrant VM
+  ansible.builtin.import_playbook: ../../../../molecule/shared/prepare-vagrant.yml

--- a/ansible/roles/system_update/tasks/archlinux.yml
+++ b/ansible/roles/system_update/tasks/archlinux.yml
@@ -1,0 +1,28 @@
+---
+- name: "Arch Linux | Refresh package databases (pacman -Sy)"
+  community.general.pacman:
+    update_cache: true
+  retries: "{{ system_update_retries }}"
+  delay: "{{ system_update_retry_delay }}"
+  register: _system_update_arch_cache
+  until: _system_update_arch_cache is succeeded
+  tags: ['system_update', 'upgrade', 'pacman']
+
+- name: "Arch Linux | Update archlinux-keyring before full upgrade"
+  community.general.pacman:
+    name: archlinux-keyring
+    state: latest
+  retries: "{{ system_update_retries }}"
+  delay: "{{ system_update_retry_delay }}"
+  register: _system_update_arch_keyring
+  until: _system_update_arch_keyring is succeeded
+  tags: ['system_update', 'upgrade', 'pacman', 'keyring']
+
+- name: "Arch Linux | Full system upgrade (pacman -Su)"
+  community.general.pacman:
+    upgrade: true
+  retries: "{{ system_update_retries }}"
+  delay: "{{ system_update_retry_delay }}"
+  register: _system_update_arch_upgrade
+  until: _system_update_arch_upgrade is succeeded
+  tags: ['system_update', 'upgrade', 'pacman']

--- a/ansible/roles/system_update/tasks/debian.yml
+++ b/ansible/roles/system_update/tasks/debian.yml
@@ -1,0 +1,8 @@
+---
+- name: "Debian | Stop until system update backend is implemented"
+  ansible.builtin.fail:
+    msg: >-
+      system_update backend for Debian/Ubuntu is not implemented in this slice.
+      Add an explicit apt full-upgrade backend before using task system:update on Debian family hosts.
+  when: system_update_fail_unimplemented_backends | bool
+  tags: ['system_update', 'upgrade']

--- a/ansible/roles/system_update/tasks/gentoo.yml
+++ b/ansible/roles/system_update/tasks/gentoo.yml
@@ -1,0 +1,8 @@
+---
+- name: "Gentoo | Stop until system update backend is implemented"
+  ansible.builtin.fail:
+    msg: >-
+      system_update backend for Gentoo is not implemented in this slice.
+      Add an explicit emerge/world update backend before using task system:update on Gentoo hosts.
+  when: system_update_fail_unimplemented_backends | bool
+  tags: ['system_update', 'upgrade']

--- a/ansible/roles/system_update/tasks/main.yml
+++ b/ansible/roles/system_update/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- name: System Update role
+  when: system_update_enabled | bool
+  tags: ['system_update']
+  block:
+
+    - name: Assert supported operating system
+      ansible.builtin.assert:
+        that:
+          - ansible_facts['os_family'] in _system_update_supported_os
+        fail_msg: >-
+          OS family '{{ ansible_facts['os_family'] }}' is not supported.
+          Supported: {{ _system_update_supported_os | join(', ') }}.
+        success_msg: "OS family '{{ ansible_facts['os_family'] }}' is supported"
+      tags: ['system_update']
+
+    - name: Include OS-family-specific system update backend
+      ansible.builtin.include_tasks: "{{ ansible_facts['os_family'] | lower }}.yml"
+      tags: ['system_update', 'upgrade']
+
+    - name: Verify system update boundary
+      ansible.builtin.include_tasks: verify.yml
+      tags: ['system_update', 'verify']

--- a/ansible/roles/system_update/tasks/redhat.yml
+++ b/ansible/roles/system_update/tasks/redhat.yml
@@ -1,0 +1,8 @@
+---
+- name: "RedHat | Stop until system update backend is implemented"
+  ansible.builtin.fail:
+    msg: >-
+      system_update backend for Fedora/RedHat is not implemented in this slice.
+      Add an explicit dnf upgrade backend before using task system:update on RedHat family hosts.
+  when: system_update_fail_unimplemented_backends | bool
+  tags: ['system_update', 'upgrade']

--- a/ansible/roles/system_update/tasks/verify.yml
+++ b/ansible/roles/system_update/tasks/verify.yml
@@ -1,0 +1,14 @@
+---
+- name: Gather package facts after system update
+  ansible.builtin.package_facts:
+    manager: auto
+  changed_when: false
+  tags: ['system_update', 'verify']
+
+- name: Report system update boundary
+  ansible.builtin.debug:
+    msg: >-
+      system_update completed on {{ ansible_facts['distribution'] }}
+      {{ ansible_facts['distribution_version'] | default('') }}.
+      Reboot the system before running task workstation.
+  tags: ['system_update', 'verify']

--- a/ansible/roles/system_update/tasks/void.yml
+++ b/ansible/roles/system_update/tasks/void.yml
@@ -1,0 +1,8 @@
+---
+- name: "Void | Stop until system update backend is implemented"
+  ansible.builtin.fail:
+    msg: >-
+      system_update backend for Void Linux is not implemented in this slice.
+      Add an explicit xbps upgrade backend before using task system:update on Void hosts.
+  when: system_update_fail_unimplemented_backends | bool
+  tags: ['system_update', 'upgrade']

--- a/ansible/roles/system_update/vars/archlinux.yml
+++ b/ansible/roles/system_update/vars/archlinux.yml
@@ -1,0 +1,2 @@
+---
+_system_update_backend: pacman

--- a/ansible/roles/system_update/vars/debian.yml
+++ b/ansible/roles/system_update/vars/debian.yml
@@ -1,0 +1,2 @@
+---
+_system_update_backend: apt

--- a/ansible/roles/system_update/vars/gentoo.yml
+++ b/ansible/roles/system_update/vars/gentoo.yml
@@ -1,0 +1,2 @@
+---
+_system_update_backend: portage

--- a/ansible/roles/system_update/vars/redhat.yml
+++ b/ansible/roles/system_update/vars/redhat.yml
@@ -1,0 +1,2 @@
+---
+_system_update_backend: dnf

--- a/ansible/roles/system_update/vars/void.yml
+++ b/ansible/roles/system_update/vars/void.yml
@@ -1,0 +1,2 @@
+---
+_system_update_backend: xbps

--- a/scripts/ssh-run.sh
+++ b/scripts/ssh-run.sh
@@ -4,7 +4,6 @@
 # Usage:
 #   ./scripts/ssh-run.sh <command>
 #   ./scripts/ssh-run.sh --bootstrap-secrets <command>
-#   ./scripts/ssh-run.sh --bootstrap-secrets --retry-on-kernel-mismatch <command>
 #   ./scripts/ssh-run.sh "ls -la"
 #   ./scripts/ssh-run.sh "df -h && free -m"
 #
@@ -22,16 +21,11 @@ if [[ -n "${SSH_PORT}" ]]; then
     SSH_OPTS+=(-p "${SSH_PORT}")
 fi
 FORWARD_BOOTSTRAP_SECRETS=0
-RETRY_ON_KERNEL_MISMATCH=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --bootstrap-secrets)
             FORWARD_BOOTSTRAP_SECRETS=1
-            shift
-            ;;
-        --retry-on-kernel-mismatch)
-            RETRY_ON_KERNEL_MISMATCH=1
             shift
             ;;
         --)
@@ -47,13 +41,7 @@ done
 if [[ $# -eq 0 ]]; then
     echo "Usage: $0 <command>" >&2
     echo "       $0 --bootstrap-secrets <command>" >&2
-    echo "       $0 --bootstrap-secrets --retry-on-kernel-mismatch <command>" >&2
     echo "Example: $0 'ls -la'" >&2
-    exit 1
-fi
-
-if [[ "${RETRY_ON_KERNEL_MISMATCH}" -eq 1 && "${FORWARD_BOOTSTRAP_SECRETS}" -eq 0 ]]; then
-    echo "ERROR: --retry-on-kernel-mismatch requires --bootstrap-secrets." >&2
     exit 1
 fi
 
@@ -85,78 +73,6 @@ run_remote_command() {
         ssh "${SSH_OPTS[@]}" "$SSH_HOST" "bash -c ${remote_wrapper_quoted} _ ${remote_command_quoted}"
 }
 
-ssh_can_connect() {
-    ssh "${SSH_OPTS[@]}" "$SSH_HOST" "true" >/dev/null 2>&1
-}
-
-remote_running_kernel_has_matching_modules() {
-    run_remote_command 'test -d "/usr/lib/modules/$(uname -r)"' >/dev/null 2>&1
-}
-
-wait_for_ssh_state() {
-    local desired_state="$1"
-    local max_attempts="$2"
-    local delay_seconds="$3"
-    local attempt=1
-
-    while (( attempt <= max_attempts )); do
-        if ssh_can_connect; then
-            if [[ "${desired_state}" == "up" ]]; then
-                return 0
-            fi
-        elif [[ "${desired_state}" == "down" ]]; then
-            return 0
-        fi
-
-        sleep "${delay_seconds}"
-        (( attempt += 1 ))
-    done
-
-    return 1
-}
-
-schedule_remote_reboot() {
-    run_remote_command "printf '%s\\n' \"\$BOOTSTRAP_SUDO_PASSWORD\" | sudo -S -p '' -- systemd-run --unit bootstrap-kernel-mismatch-reboot --on-active=2 /usr/bin/systemctl reboot" >/dev/null
-}
-
-run_with_optional_kernel_retry() {
-    local rc
-
-    if run_remote_command "${COMMAND}"; then
-        return 0
-    fi
-    rc=$?
-
-    if [[ "${RETRY_ON_KERNEL_MISMATCH}" -eq 0 ]]; then
-        return "${rc}"
-    fi
-
-    if ! ssh_can_connect; then
-        return "${rc}"
-    fi
-
-    if remote_running_kernel_has_matching_modules; then
-        return "${rc}"
-    fi
-
-    echo "NOTICE: Remote command failed after the running kernel lost its matching modules directory." >&2
-    echo "NOTICE: Rebooting the disposable VM once and retrying the same command." >&2
-
-    schedule_remote_reboot
-
-    if ! wait_for_ssh_state down 24 5; then
-        echo "ERROR: SSH never went down after scheduling the remote reboot." >&2
-        return "${rc}"
-    fi
-
-    if ! wait_for_ssh_state up 48 5; then
-        echo "ERROR: SSH did not return after the remote reboot." >&2
-        return "${rc}"
-    fi
-
-    run_remote_command "${COMMAND}"
-}
-
 if [[ "${FORWARD_BOOTSTRAP_SECRETS}" -eq 1 ]]; then
     # shellcheck source=/dev/null
     source "${SCRIPT_DIR}/bootstrap-env.sh"
@@ -164,4 +80,4 @@ if [[ "${FORWARD_BOOTSTRAP_SECRETS}" -eq 1 ]]; then
     SUDO_PASS="$(bootstrap_sudo_password)"
 fi
 
-run_with_optional_kernel_retry
+run_remote_command "${COMMAND}"

--- a/scripts/ssh-scp-to.sh
+++ b/scripts/ssh-scp-to.sh
@@ -3,7 +3,11 @@
 #
 # Usage:
 #   ./scripts/ssh-scp-to.sh --project              # Sync entire project
+#   ./scripts/ssh-scp-to.sh --project --clean-venv # Sync project and rebuild venv later
 #   ./scripts/ssh-scp-to.sh [-r] <src>... <dest>   # Copy specific files
+#
+# Environment:
+#   BOOTSTRAP_SYNC_PRESERVE_REMOTE_VENV=0 disables preserving the VM's Linux venv.
 
 set -euo pipefail
 
@@ -20,9 +24,45 @@ fi
 
 # Project sync mode
 if [[ "${1:-}" == "--project" ]]; then
+    shift
+
+    PRESERVE_REMOTE_VENV="${BOOTSTRAP_SYNC_PRESERVE_REMOTE_VENV:-1}"
+    REMOTE_VENV_STASH=""
+    REMOTE_VENV_STASH_ACTIVE=0
+
+    restore_remote_venv() {
+        if [[ "${PRESERVE_REMOTE_VENV}" != "0" && "${REMOTE_VENV_STASH_ACTIVE}" -eq 1 ]]; then
+            ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" \
+                "if [ -d '${REMOTE_VENV_STASH}' ]; then mkdir -p '${REMOTE_BASE}/ansible'; rm -rf '${REMOTE_BASE}/ansible/.venv'; mv '${REMOTE_VENV_STASH}' '${REMOTE_BASE}/ansible/.venv'; fi" \
+                2>/dev/null || true
+        fi
+    }
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --clean-venv|--no-preserve-venv)
+                PRESERVE_REMOTE_VENV=0
+                ;;
+            *)
+                echo "Unknown --project option: $1" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
     echo "==> Syncing project to ${SSH_HOST}:${REMOTE_BASE}"
+    REMOTE_VENV_STASH="/tmp/bootstrap-ansible-venv-${RANDOM}-${RANDOM}"
+    if [[ "${PRESERVE_REMOTE_VENV}" != "0" ]]; then
+        echo "  preserving remote ansible/.venv"
+        ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" \
+            "if [ -d '${REMOTE_BASE}/ansible/.venv' ]; then rm -rf '${REMOTE_VENV_STASH}'; mv '${REMOTE_BASE}/ansible/.venv' '${REMOTE_VENV_STASH}'; fi"
+        REMOTE_VENV_STASH_ACTIVE=1
+        trap restore_remote_venv EXIT
+    fi
+
     ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" \
-        "find ${REMOTE_BASE} -delete 2>/dev/null; rm -rf ${REMOTE_BASE} 2>/dev/null; true"
+        "find '${REMOTE_BASE}' -delete 2>/dev/null; rm -rf '${REMOTE_BASE}' 2>/dev/null; true"
 
     PROJECT_DIRS=(ansible dotfiles scripts)
     PROJECT_FILES=(Taskfile.yml bootstrap.sh AGENTS.md CLAUDE.md)
@@ -51,6 +91,13 @@ if [[ "${1:-}" == "--project" ]]; then
             scp -v "${SSH_OPTS[@]}" "${REPO_ROOT}/${file}" "$SSH_HOST:${REMOTE_BASE}/"
         fi
     done
+
+    if [[ "${PRESERVE_REMOTE_VENV}" != "0" ]]; then
+        echo "  restoring remote ansible/.venv"
+        restore_remote_venv
+        REMOTE_VENV_STASH_ACTIVE=0
+        trap - EXIT
+    fi
 
     # Fix permissions (Windows scp sets world-writable which breaks ansible.cfg)
     echo "  fixing directory permissions"

--- a/scripts/ssh-scp-to.sh
+++ b/scripts/ssh-scp-to.sh
@@ -3,11 +3,8 @@
 #
 # Usage:
 #   ./scripts/ssh-scp-to.sh --project              # Sync entire project
-#   ./scripts/ssh-scp-to.sh --project --clean-venv # Sync project and rebuild venv later
+#   ./scripts/ssh-scp-to.sh --project --bootstrap  # Sync project and rebuild VM venv
 #   ./scripts/ssh-scp-to.sh [-r] <src>... <dest>   # Copy specific files
-#
-# Environment:
-#   BOOTSTRAP_SYNC_PRESERVE_REMOTE_VENV=0 disables preserving the VM's Linux venv.
 
 set -euo pipefail
 
@@ -26,22 +23,11 @@ fi
 if [[ "${1:-}" == "--project" ]]; then
     shift
 
-    PRESERVE_REMOTE_VENV="${BOOTSTRAP_SYNC_PRESERVE_REMOTE_VENV:-1}"
-    REMOTE_VENV_STASH=""
-    REMOTE_VENV_STASH_ACTIVE=0
-
-    restore_remote_venv() {
-        if [[ "${PRESERVE_REMOTE_VENV}" != "0" && "${REMOTE_VENV_STASH_ACTIVE}" -eq 1 ]]; then
-            ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" \
-                "if [ -d '${REMOTE_VENV_STASH}' ]; then mkdir -p '${REMOTE_BASE}/ansible'; rm -rf '${REMOTE_BASE}/ansible/.venv'; mv '${REMOTE_VENV_STASH}' '${REMOTE_BASE}/ansible/.venv'; fi" \
-                2>/dev/null || true
-        fi
-    }
-
+    RUN_BOOTSTRAP=0
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --clean-venv|--no-preserve-venv)
-                PRESERVE_REMOTE_VENV=0
+            --bootstrap)
+                RUN_BOOTSTRAP=1
                 ;;
             *)
                 echo "Unknown --project option: $1" >&2
@@ -52,15 +38,6 @@ if [[ "${1:-}" == "--project" ]]; then
     done
 
     echo "==> Syncing project to ${SSH_HOST}:${REMOTE_BASE}"
-    REMOTE_VENV_STASH="/tmp/bootstrap-ansible-venv-${RANDOM}-${RANDOM}"
-    if [[ "${PRESERVE_REMOTE_VENV}" != "0" ]]; then
-        echo "  preserving remote ansible/.venv"
-        ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" \
-            "if [ -d '${REMOTE_BASE}/ansible/.venv' ]; then rm -rf '${REMOTE_VENV_STASH}'; mv '${REMOTE_BASE}/ansible/.venv' '${REMOTE_VENV_STASH}'; fi"
-        REMOTE_VENV_STASH_ACTIVE=1
-        trap restore_remote_venv EXIT
-    fi
-
     ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" \
         "find '${REMOTE_BASE}' -delete 2>/dev/null; rm -rf '${REMOTE_BASE}' 2>/dev/null; true"
 
@@ -92,13 +69,6 @@ if [[ "${1:-}" == "--project" ]]; then
         fi
     done
 
-    if [[ "${PRESERVE_REMOTE_VENV}" != "0" ]]; then
-        echo "  restoring remote ansible/.venv"
-        restore_remote_venv
-        REMOTE_VENV_STASH_ACTIVE=0
-        trap - EXIT
-    fi
-
     # Fix permissions (Windows scp sets world-writable which breaks ansible.cfg)
     echo "  fixing directory permissions"
     ssh "${SSH_OPTS[@]/-P/-p}" "$SSH_HOST" "chmod -R u+rwX,go+rX,go-w ${REMOTE_BASE}"
@@ -107,6 +77,12 @@ if [[ "${1:-}" == "--project" ]]; then
         "chmod +x ${REMOTE_BASE}/bootstrap.sh \
                   ${REMOTE_BASE}/scripts/*.sh \
                   ${REMOTE_BASE}/ansible/vault-pass.sh"
+
+    if [[ "${RUN_BOOTSTRAP}" -eq 1 ]]; then
+        echo "  bootstrapping remote ansible environment"
+        SSH_HOST="${SSH_HOST}" SSH_PORT="${SSH_PORT}" "${SCRIPT_DIR}/ssh-run.sh" --bootstrap-secrets \
+            "cd ${REMOTE_BASE} && scripts/setup-venv.sh && scripts/setup-galaxy.sh"
+    fi
 
     echo "==> Sync complete"
     exit 0

--- a/wiki/Ansible-Overview.md
+++ b/wiki/Ansible-Overview.md
@@ -77,9 +77,9 @@ task test-base-system     # Конкретная роль
 
 ```bash
 # Выборочный запуск
-ansible-playbook playbooks/workstation.yml --tags packages
-ansible-playbook playbooks/workstation.yml --tags "docker,ssh,firewall"
-ansible-playbook playbooks/workstation.yml --skip-tags firewall
+task workstation -- --tags packages
+task workstation -- --tags "docker,ssh,firewall"
+task workstation -- --skip-tags firewall
 ```
 
 ## Структура проекта

--- a/wiki/standards/test-vm-workflow.md
+++ b/wiki/standards/test-vm-workflow.md
@@ -72,8 +72,8 @@ All playbook execution goes through the Taskfile. **NEVER** run `ansible-playboo
 
 | Command | What it does |
 |---------|-------------|
-| `task workstation` | Full workstation playbook (`-v` auto) |
-| `task workstation -- --skip-tags "x,y"` | Playbook with tag filtering |
+| `task system:update` | Full OS package upgrade before reboot/workstation (`-v` auto) |
+| `task workstation` | Full workstation configuration playbook (`-v` auto) |
 | `task check` | Syntax check all playbooks |
 | `task lint` | ansible-lint on all roles |
 | `task bootstrap` | Install venv + galaxy deps (first-time setup) |
@@ -249,33 +249,28 @@ SSH_HOST=arch-127.0.0.1-2223 bash scripts/ssh-run.sh --bootstrap-secrets \
   "cd ~/bootstrap && task check"
 ```
 
-### Step 3: Run Playbook (Run 1)
+### Step 3: Run System Update
 
-Full playbook from beginning through a specific role using `--skip-tags`:
+Run the pre-workstation system update entrypoint. This step performs only the
+operating-system package upgrade. It must not install the workstation package
+set, AUR packages, Docker, VM integration, desktop roles, or dotfiles.
 
 ```bash
 SSH_HOST=arch-127.0.0.1-2223 bash scripts/ssh-run.sh --bootstrap-secrets \
-  --retry-on-kernel-mismatch \
-  "cd ~/bootstrap && task --yes workstation -- \
-  --skip-tags 'git,shell,docker,firewall,caddy,vaultwarden,xorg,lightdm,greeter,zen_browser,chezmoi'"
+  "cd ~/bootstrap && task --yes system:update"
 ```
 
-Use `--retry-on-kernel-mismatch` for unattended disposable-clone runs. If the
-`packages` phase upgrades the kernel on disk and the running clone loses its
-matching `/usr/lib/modules/<uname -r>` directory, the existing host-side
-execution script schedules one reboot of the disposable VM, waits for SSH to
-return, and retries the same `task` command once. This keeps the controller on
-the host side, which is required when Ansible itself is running on the VM with
-`ansible_connection=local`.
+After a successful `task system:update`, reboot the disposable clone through the
+project-approved VM workflow. The reboot boundary deliberately starts a new
+runtime; no Ansible checkpoint or resume state is carried across it.
 
-**Scope reference** — roles in `playbooks/workstation.yml` order:
+After the VM returns, run the workstation entrypoint through the same
+secret-forwarding path:
 
-| Stop after | Skip tags |
-|------------|-----------|
-| fail2ban | `git,shell,docker,firewall,caddy,vaultwarden,xorg,lightdm,greeter,zen_browser,chezmoi` |
-| ssh | `teleport,fail2ban,git,shell,docker,firewall,caddy,vaultwarden,xorg,lightdm,greeter,zen_browser,chezmoi` |
-| packages | `user,ssh_keys,ssh,teleport,fail2ban,git,shell,docker,firewall,caddy,vaultwarden,xorg,lightdm,greeter,zen_browser,chezmoi` |
-| full playbook | *(no skip)* |
+```bash
+SSH_HOST=arch-127.0.0.1-2223 bash scripts/ssh-run.sh --bootstrap-secrets \
+  "cd ~/bootstrap && task --yes workstation"
+```
 
 **If a role fails:**
 1. Record the full error output


### PR DESCRIPTION
Move full OS upgrade out of workstation into a dedicated system_update playbook and role. Keep workstation/package installation after the reboot boundary, remove the host-side kernel mismatch retry path, and make the Arch backend refresh databases, update archlinux-keyring, then run the full upgrade.