### PR TITLE
[codex] Refactor reflector update workflow and tests

### DIFF
--- a/ansible/roles/reflector/README.md
+++ b/ansible/roles/reflector/README.md
@@ -14,7 +14,7 @@ Pacman mirror list optimization via [reflector](https://wiki.archlinux.org/title
 - [x] Backs up current mirrorlist before update (timestamped, with rotation)
 - [x] Runs `reflector` with configurable retries and validates the output contains `Server =` entries
 - [x] Restores backup on failure (rescue block)
-- [x] Refreshes pacman cache after mirrorlist update
+- [x] Skips manual mirrorlist refresh when the existing mirrorlist was updated recently
 
 ## Variables
 
@@ -35,6 +35,7 @@ Pacman mirror list optimization via [reflector](https://wiki.archlinux.org/title
 | `reflector_connection_timeout` | `10` | Connection timeout in seconds |
 | `reflector_download_timeout` | `30` | Download timeout in seconds |
 | `reflector_proxy` | `""` | HTTP/HTTPS proxy (empty = no proxy) |
+| `reflector_update_min_interval` | `3600` | Minimum seconds between manual mirrorlist updates |
 | `reflector_backup_keep` | `3` | Max backup files to retain (`0` = unlimited) |
 | `reflector_timer_randomized_delay` | `"1h"` | `RandomizedDelaySec` for timer |
 | `reflector_pacman_hook` | `true` | Deploy pacman hook for auto-update on mirror package upgrade |

--- a/ansible/roles/reflector/defaults/main.yml
+++ b/ansible/roles/reflector/defaults/main.yml
@@ -30,7 +30,7 @@ reflector_retry_delay: 5
 reflector_connection_timeout: 10
 reflector_download_timeout: 30
 reflector_proxy: ""
-reflector_pacman_cache_valid_time: 3600
+reflector_update_min_interval: 3600  # Minimum seconds between mirrorlist updates
 
 # Backup rotation: how many timestamped backups to keep (0 = keep all)
 reflector_backup_keep: 3

--- a/ansible/roles/reflector/molecule/README.md
+++ b/ansible/roles/reflector/molecule/README.md
@@ -1,134 +1,45 @@
 # Molecule Testing
 
-## Что это?
+This role has two meaningful Molecule contracts:
 
-Molecule - фреймворк для автоматизированного тестирования Ansible ролей.
+- `docker`: offline contract. Installs/configures reflector, enables the timer, deploys the pacman hook, and checks idempotence with `--skip-tags update`.
+- `vagrant`: full Arch VM contract. Runs the online mirrorlist update, checks idempotence, verifies check mode does not mutate mirrorlist state, then validates mirrorlist and backup rotation.
 
-**Как работает:**
-1. **Converge** - применяет роль к системе
-2. **Verify** - автоматически проверяет результат
-3. **Idempotence** - проверяет идемпотентность
+## Docker
 
-## Для вашего случая (Arch Linux VM)
+Docker is the fast CI path. It intentionally skips `update` because mirror selection is network-dependent and writes `/etc/pacman.d/mirrorlist`.
 
-Вы уже работаете в Arch Linux VM, поэтому Molecule будет применять роль **прямо к вашей системе**.
+Checks:
 
-### ⚠️ ВАЖНО: Molecule ИЗМЕНЯЕТ систему!
+- `reflector` package is installed.
+- `reflector.conf` exists, is root-owned, mode `0644`, and contains expected directives.
+- `reflector.timer` drop-in exists and contains expected schedule values.
+- `reflector.timer` is enabled.
+- Optional pacman hook exists and references `pacman-mirrorlist` plus `--config`.
+- Idempotence passes for the offline contract.
 
-**Что будет изменено:**
-- Установлен пакет `reflector`
-- Создан `/etc/xdg/reflector/reflector.conf`
-- Настроен `reflector.timer` в systemd
-- Обновлен `/etc/pacman.d/mirrorlist`
+## Vagrant
 
-**Перед запуском:**
-1. Создайте снапшот VM в VirtualBox
-2. Запустите `task test`
-3. Если всё ок - оставьте изменения
-4. Если что-то не так - откатите снапшот
+Vagrant is the full contract test for the role on an Arch VM.
 
-## Запуск тестов
+Checks:
 
-### Синтаксис и линтинг (безопасно)
+- Everything from the Docker/offline contract.
+- Full role idempotence after the first converge.
+- Check mode does not mutate the mirrorlist content or backup count.
+- `reflector_mirrorlist_path` exists, is non-empty, and contains active `Server =` entries.
+- The mirrorlist is not older than `reflector_conf_path`.
+- Backup count does not exceed `reflector_backup_keep`.
+
+## Running
+
+Project policy requires role tests to run through the VM/Taskfile workflow. The scenario commands below document the underlying Molecule targets used by that workflow.
+
+Typical role commands:
+
 ```bash
-task check  # Проверка синтаксиса
-task lint   # Ansible-lint
-task all    # Синтаксис + линтинг
+molecule test -s docker
+molecule test -s vagrant --platform-name arch-vm
 ```
 
-### Molecule (изменяет систему!)
-```bash
-# 1. В VirtualBox: VM → Снапшоты → Создать
-# 2. Запустить тесты
-task test
-
-# 3a. Если всё ок - оставить изменения
-# 3b. Если нет - откатить снапшот в VirtualBox
-```
-
-## Что проверяет Molecule?
-
-После применения роли автоматически проверяет:
-
-1. ✅ Пакет `reflector` установлен
-2. ✅ Конфиг `/etc/xdg/reflector/reflector.conf` существует
-3. ✅ Конфиг содержит правильные параметры
-4. ✅ Systemd таймер настроен
-5. ✅ Таймер включен и запущен
-6. ✅ Mirrorlist обновлен и содержит серверы
-
-## Рабочий процесс
-
-### Разработка
-```bash
-# Быстрая проверка без изменений
-task check
-task lint
-
-# При необходимости - применить к системе
-ansible-playbook playbooks/mirrors-update.yml
-```
-
-### Перед коммитом
-```bash
-# Полная проверка с автоматической верификацией
-task test
-```
-
-## Альтернативы
-
-### 1. Ручная проверка (без Molecule)
-```bash
-ansible-playbook playbooks/mirrors-update.yml
-
-# Вручную проверяем:
-systemctl status reflector.timer
-cat /etc/pacman.d/mirrorlist
-cat /etc/xdg/reflector/reflector.conf
-```
-**Минус:** Легко забыть что-то проверить
-
-### 2. Check mode (dry-run)
-```bash
-ansible-playbook playbooks/mirrors-update.yml --check --diff
-```
-**Минус:** Не все модули поддерживают, не проверяет реальный результат
-
-### 3. Molecule (текущий подход)
-```bash
-task test
-```
-**Плюс:** Автоматически проверяет ВСЁ
-**Минус:** Изменяет систему (нужен снапшот)
-
-## Почему не Docker/Vagrant?
-
-**Docker:**
-- ❌ Нет полноценного systemd
-- ❌ Arch Linux образы нестабильны
-
-**Vagrant:**
-- ❌ Вы уже в VM (nested virtualization медленно)
-- ❌ Избыточно
-
-**Delegated driver (localhost):**
-- ✅ Вы УЖЕ на Arch Linux
-- ✅ Просто делаете снапшот VM
-- ✅ Быстро и просто
-
-## FAQ
-
-**Q: Безопасно ли запускать `task test`?**
-A: НЕТ! Роль будет применена к вашей системе. Создайте снапшот VM перед запуском.
-
-**Q: Как откатить изменения?**
-A: В VirtualBox: VM → Снапшоты → Восстановить нужный снапшот.
-
-**Q: Можно ли протестировать без изменения системы?**
-A: Частично - используйте `task check` и `task lint` для проверки синтаксиса. Для полной проверки нужно применять роль.
-
-**Q: Зачем Molecule если можно просто запустить playbook?**
-A: Molecule **автоматически проверяет** результат (systemd, файлы, содержимое). Без него вы проверяете вручную и можете что-то пропустить.
-
-**Q: Что если я не хочу создавать снапшоты?**
-A: Тогда просто применяйте роль напрямую: `ansible-playbook playbooks/mirrors-update.yml`. Molecule нужен только для автоматизированного тестирования.
+The delegated `default` scenario applies the full role to the current host and is not the CI path. Use it only on a disposable Arch VM snapshot.

--- a/ansible/roles/reflector/molecule/default/molecule.yml
+++ b/ansible/roles/reflector/molecule/default/molecule.yml
@@ -25,7 +25,7 @@ provisioner:
         ansible_connection: local
   playbooks:
     converge: ../shared/converge.yml
-    verify: ../shared/verify.yml
+    verify: ../shared/verify-full.yml
   env:
     ANSIBLE_ROLES_PATH: "${MOLECULE_PROJECT_DIRECTORY}/roles"
 

--- a/ansible/roles/reflector/molecule/shared/verify-full.yml
+++ b/ansible/roles/reflector/molecule/shared/verify-full.yml
@@ -1,8 +1,5 @@
 ---
-# Full Vagrant verify for reflector role.
-# reflector is Arch-only. Ubuntu gets end_host.
-
-- name: Verify reflector role
+- name: Verify reflector full contract
   hosts: all
   become: true
   gather_facts: true
@@ -10,27 +7,23 @@
     - ../../defaults/main.yml
 
   tasks:
-    - name: Skip verify on non-Arch systems
-      ansible.builtin.meta: end_host
-      when: ansible_facts['os_family'] != 'Archlinux'
-
     - name: Verify reflector package
-      ansible.builtin.import_tasks: ../shared/verify/package.yml
+      ansible.builtin.import_tasks: verify/package.yml
 
     - name: Verify reflector config
-      ansible.builtin.import_tasks: ../shared/verify/config.yml
+      ansible.builtin.import_tasks: verify/config.yml
 
     - name: Verify reflector timer
-      ansible.builtin.import_tasks: ../shared/verify/timer.yml
+      ansible.builtin.import_tasks: verify/timer.yml
 
     - name: Verify reflector pacman hook
-      ansible.builtin.import_tasks: ../shared/verify/hook.yml
+      ansible.builtin.import_tasks: verify/hook.yml
 
     - name: Verify reflector mirrorlist
-      ansible.builtin.import_tasks: ../shared/verify/mirrorlist.yml
+      ansible.builtin.import_tasks: verify/mirrorlist.yml
 
     - name: Verify reflector backup rotation
-      ansible.builtin.import_tasks: ../shared/verify/backups.yml
+      ansible.builtin.import_tasks: verify/backups.yml
 
     - name: Show full verify result
       ansible.builtin.debug:

--- a/ansible/roles/reflector/molecule/shared/verify.yml
+++ b/ansible/roles/reflector/molecule/shared/verify.yml
@@ -1,5 +1,5 @@
 ---
-- name: Verify reflector role
+- name: Verify reflector offline contract
   hosts: all
   become: true
   gather_facts: true
@@ -7,207 +7,21 @@
     - ../../defaults/main.yml
 
   tasks:
+    - name: Verify reflector package
+      ansible.builtin.import_tasks: verify/package.yml
 
-    # ---- Package installed ----
+    - name: Verify reflector config
+      ansible.builtin.import_tasks: verify/config.yml
 
-    - name: Gather package facts
-      ansible.builtin.package_facts:
-        manager: auto
+    - name: Verify reflector timer
+      ansible.builtin.import_tasks: verify/timer.yml
 
-    - name: Assert reflector package is installed
-      ansible.builtin.assert:
-        that: "'reflector' in ansible_facts.packages"
-        fail_msg: "reflector package not found"
+    - name: Verify reflector pacman hook
+      ansible.builtin.import_tasks: verify/hook.yml
 
-    # ---- Config file ----
-
-    - name: Stat reflector config
-      ansible.builtin.stat:
-        path: "{{ reflector_conf_path }}"
-      register: _reflector_verify_conf_stat
-
-    - name: Assert reflector config exists with correct permissions
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_conf_stat.stat.exists
-          - _reflector_verify_conf_stat.stat.isreg
-          - _reflector_verify_conf_stat.stat.pw_name == 'root'
-          - _reflector_verify_conf_stat.stat.mode == '0644'
-        fail_msg: "{{ reflector_conf_path }} missing or wrong permissions"
-
-    - name: Read reflector config content
-      ansible.builtin.slurp:
-        src: "{{ reflector_conf_path }}"
-      register: _reflector_verify_conf_raw
-
-    - name: Assert config content was read
-      ansible.builtin.assert:
-        that: "'content' in _reflector_verify_conf_raw"
-        fail_msg: "Failed to read reflector config content"
-
-    - name: Set config text fact
-      ansible.builtin.set_fact:
-        _reflector_verify_conf_text: "{{ _reflector_verify_conf_raw.content | b64decode }}"
-
-    - name: Assert config contains expected directives
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_conf_text is regex('--protocol\s+' ~ reflector_protocol)
-          - _reflector_verify_conf_text is regex('--sort\s+' ~ reflector_sort)
-          - _reflector_verify_conf_text is regex('--latest\s+' ~ reflector_latest | string)
-          - _reflector_verify_conf_text is regex('--age\s+' ~ reflector_age | string)
-          - _reflector_verify_conf_text is regex('--country\s+' ~ reflector_countries)
-          - _reflector_verify_conf_text is regex('--save\s+' ~ reflector_mirrorlist_path)
-          - _reflector_verify_conf_text is regex('--threads\s+' ~ reflector_threads | string)
-          - _reflector_verify_conf_text is regex('--connection-timeout\s+' ~ reflector_connection_timeout | string)
-          - _reflector_verify_conf_text is regex('--download-timeout\s+' ~ reflector_download_timeout | string)
-        fail_msg: "reflector.conf missing expected directives"
-
-    # ---- Timer drop-in ----
-
-    - name: Stat timer drop-in
-      ansible.builtin.stat:
-        path: /etc/systemd/system/reflector.timer.d/override.conf
-      register: _reflector_verify_dropin_stat
-
-    - name: Assert timer drop-in exists
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_dropin_stat.stat.exists
-          - _reflector_verify_dropin_stat.stat.isreg
-        fail_msg: "Timer drop-in /etc/systemd/system/reflector.timer.d/override.conf missing"
-
-    - name: Read timer drop-in content
-      ansible.builtin.slurp:
-        src: /etc/systemd/system/reflector.timer.d/override.conf
-      register: _reflector_verify_dropin_raw
-
-    - name: Assert drop-in content was read
-      ansible.builtin.assert:
-        that: "'content' in _reflector_verify_dropin_raw"
-        fail_msg: "Failed to read timer drop-in content"
-
-    - name: Assert timer drop-in contains expected values
-      ansible.builtin.assert:
-        that:
-          - (_reflector_verify_dropin_raw.content | b64decode) is regex('OnCalendar=' ~ reflector_timer_schedule)
-          - (_reflector_verify_dropin_raw.content | b64decode) is regex('RandomizedDelaySec=' ~ reflector_timer_randomized_delay)
-        fail_msg: "Timer drop-in missing OnCalendar or RandomizedDelaySec"
-
-    # ---- Timer service state ----
-
-    - name: Check reflector.timer is enabled
-      ansible.builtin.command:
-        cmd: systemctl is-enabled reflector.timer
-      register: _reflector_verify_timer_enabled
-      changed_when: false
-      failed_when: false
-
-    - name: Assert reflector.timer is enabled
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_timer_enabled.rc == 0
-          - _reflector_verify_timer_enabled.stdout is regex('^enabled')
-        fail_msg: "reflector.timer is not enabled (rc: {{ _reflector_verify_timer_enabled.rc }}, stdout: {{ _reflector_verify_timer_enabled.stdout | default('') }})"
-
-    # ---- Pacman hook ----
-
-    - name: Stat pacman hooks directory
-      ansible.builtin.stat:
-        path: /etc/pacman.d/hooks
-      register: _reflector_verify_hooks_dir
-      when: reflector_pacman_hook | bool
-
-    - name: Assert pacman hooks directory exists
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_hooks_dir.stat.exists
-          - _reflector_verify_hooks_dir.stat.isdir
-        fail_msg: "/etc/pacman.d/hooks directory missing"
-      when: reflector_pacman_hook | bool
-
-    - name: Stat pacman hook file
-      ansible.builtin.stat:
-        path: /etc/pacman.d/hooks/reflector-mirrorlist.hook
-      register: _reflector_verify_hook_stat
-      when: reflector_pacman_hook | bool
-
-    - name: Assert pacman hook file exists
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_hook_stat.stat.exists
-          - _reflector_verify_hook_stat.stat.isreg
-        fail_msg: "Pacman hook /etc/pacman.d/hooks/reflector-mirrorlist.hook missing"
-      when: reflector_pacman_hook | bool
-
-    - name: Read pacman hook content
-      ansible.builtin.slurp:
-        src: /etc/pacman.d/hooks/reflector-mirrorlist.hook
-      register: _reflector_verify_hook_raw
-      when: reflector_pacman_hook | bool
-
-    - name: Assert hook content was read
-      ansible.builtin.assert:
-        that: "'content' in _reflector_verify_hook_raw"
-        fail_msg: "Failed to read pacman hook content"
-      when: reflector_pacman_hook | bool
-
-    - name: Assert hook content references pacman-mirrorlist and --config
-      ansible.builtin.assert:
-        that:
-          - "(_reflector_verify_hook_raw.content | b64decode) is regex('pacman-mirrorlist')"
-          - "(_reflector_verify_hook_raw.content | b64decode) is regex('--config')"
-        fail_msg: "Hook file missing expected content (pacman-mirrorlist or --config)"
-      when: reflector_pacman_hook | bool
-
-    # ---- Mirrorlist (online checks -- only when update was run) ----
-
-    - name: Stat mirrorlist
-      ansible.builtin.stat:
-        path: "{{ reflector_mirrorlist_path }}"
-      register: _reflector_verify_mirrorlist
-
-    - name: Validate mirrorlist contains Server entries
-      ansible.builtin.command:
-        cmd: grep -c '^Server = ' {{ reflector_mirrorlist_path }}
-      register: _reflector_verify_server_count
-      changed_when: false
-      failed_when: _reflector_verify_server_count.stdout | int < 1
-      when:
-        - _reflector_verify_mirrorlist.stat.exists
-        - _reflector_verify_mirrorlist.stat.size > 0
-
-    # ---- Backup rotation (online checks -- only when backups exist) ----
-
-    - name: Count mirrorlist backup files
-      ansible.builtin.find:
-        paths: "{{ reflector_mirrorlist_path | dirname }}"
-        patterns: "mirrorlist.bak.*"
-      register: _reflector_verify_backups
-      when:
-        - _reflector_verify_mirrorlist.stat.exists
-        - reflector_backup_mirrorlist | bool
-
-    - name: Assert backup count does not exceed reflector_backup_keep
-      ansible.builtin.assert:
-        that:
-          - _reflector_verify_backups.matched <= reflector_backup_keep | int
-        fail_msg: >
-          Found {{ _reflector_verify_backups.matched }} backup files,
-          expected <= {{ reflector_backup_keep }}
-      when:
-        - _reflector_verify_backups is defined
-        - not (_reflector_verify_backups is skipped)
-        - reflector_backup_keep | int > 0
-
-    # ---- Summary ----
-
-    - name: Show verify result
+    - name: Show offline verify result
       ansible.builtin.debug:
         msg: >-
-          Reflector verify passed: package installed, config deployed at
+          Reflector offline verify passed: package installed, config deployed at
           {{ reflector_conf_path }}, timer drop-in configured, timer enabled,
           pacman hook {{ 'deployed' if reflector_pacman_hook | bool else 'skipped' }}.
-          Mirrorlist: {{ 'validated (' ~ _reflector_verify_server_count.stdout | default('N/A') ~ ' servers)'
-          if (_reflector_verify_mirrorlist.stat.exists and _reflector_verify_mirrorlist.stat.size > 0)
-          else 'not checked (update was skipped)' }}.

--- a/ansible/roles/reflector/molecule/shared/verify/backups.yml
+++ b/ansible/roles/reflector/molecule/shared/verify/backups.yml
@@ -1,0 +1,18 @@
+---
+- name: Count mirrorlist backup files
+  ansible.builtin.find:
+    paths: "{{ reflector_mirrorlist_path | dirname }}"
+    patterns: "{{ reflector_mirrorlist_path | basename }}.bak.*"
+  register: _reflector_verify_backups
+  when: reflector_backup_mirrorlist | bool
+
+- name: Assert backup count does not exceed reflector_backup_keep
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_backups.matched <= reflector_backup_keep | int
+    fail_msg: >-
+      Found {{ _reflector_verify_backups.matched }} backup files,
+      expected <= {{ reflector_backup_keep }}
+  when:
+    - reflector_backup_mirrorlist | bool
+    - reflector_backup_keep | int > 0

--- a/ansible/roles/reflector/molecule/shared/verify/config.yml
+++ b/ansible/roles/reflector/molecule/shared/verify/config.yml
@@ -1,0 +1,37 @@
+---
+- name: Stat reflector config
+  ansible.builtin.stat:
+    path: "{{ reflector_conf_path }}"
+  register: _reflector_verify_conf_stat
+
+- name: Assert reflector config exists with correct permissions
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_conf_stat.stat.exists
+      - _reflector_verify_conf_stat.stat.isreg
+      - _reflector_verify_conf_stat.stat.pw_name == 'root'
+      - _reflector_verify_conf_stat.stat.mode == '0644'
+    fail_msg: "{{ reflector_conf_path }} missing or wrong permissions"
+
+- name: Read reflector config content
+  ansible.builtin.slurp:
+    src: "{{ reflector_conf_path }}"
+  register: _reflector_verify_conf_raw
+
+- name: Decode reflector config content
+  ansible.builtin.set_fact:
+    _reflector_verify_conf_text: "{{ _reflector_verify_conf_raw.content | b64decode }}"
+
+- name: Assert config contains expected directives
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_conf_text is regex('--protocol\s+' ~ reflector_protocol)
+      - _reflector_verify_conf_text is regex('--sort\s+' ~ reflector_sort)
+      - _reflector_verify_conf_text is regex('--latest\s+' ~ (reflector_latest | string))
+      - _reflector_verify_conf_text is regex('--age\s+' ~ (reflector_age | string))
+      - _reflector_verify_conf_text is regex('--country\s+' ~ reflector_countries)
+      - _reflector_verify_conf_text is regex('--save\s+' ~ reflector_mirrorlist_path)
+      - _reflector_verify_conf_text is regex('--threads\s+' ~ (reflector_threads | string))
+      - _reflector_verify_conf_text is regex('--connection-timeout\s+' ~ (reflector_connection_timeout | string))
+      - _reflector_verify_conf_text is regex('--download-timeout\s+' ~ (reflector_download_timeout | string))
+    fail_msg: "reflector.conf missing expected directives"

--- a/ansible/roles/reflector/molecule/shared/verify/hook.yml
+++ b/ansible/roles/reflector/molecule/shared/verify/hook.yml
@@ -1,0 +1,47 @@
+---
+- name: Stat pacman hooks directory
+  ansible.builtin.stat:
+    path: /etc/pacman.d/hooks
+  register: _reflector_verify_hooks_dir
+  when: reflector_pacman_hook | bool
+
+- name: Assert pacman hooks directory exists
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_hooks_dir.stat.exists
+      - _reflector_verify_hooks_dir.stat.isdir
+    fail_msg: "/etc/pacman.d/hooks directory missing"
+  when: reflector_pacman_hook | bool
+
+- name: Stat pacman hook file
+  ansible.builtin.stat:
+    path: /etc/pacman.d/hooks/reflector-mirrorlist.hook
+  register: _reflector_verify_hook_stat
+  when: reflector_pacman_hook | bool
+
+- name: Assert pacman hook file exists
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_hook_stat.stat.exists
+      - _reflector_verify_hook_stat.stat.isreg
+    fail_msg: "Pacman hook /etc/pacman.d/hooks/reflector-mirrorlist.hook missing"
+  when: reflector_pacman_hook | bool
+
+- name: Read pacman hook content
+  ansible.builtin.slurp:
+    src: /etc/pacman.d/hooks/reflector-mirrorlist.hook
+  register: _reflector_verify_hook_raw
+  when: reflector_pacman_hook | bool
+
+- name: Decode pacman hook content
+  ansible.builtin.set_fact:
+    _reflector_verify_hook_text: "{{ _reflector_verify_hook_raw.content | b64decode }}"
+  when: reflector_pacman_hook | bool
+
+- name: Assert hook content references pacman-mirrorlist and --config
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_hook_text is regex('pacman-mirrorlist')
+      - _reflector_verify_hook_text is regex('--config')
+    fail_msg: "Hook file missing expected content (pacman-mirrorlist or --config)"
+  when: reflector_pacman_hook | bool

--- a/ansible/roles/reflector/molecule/shared/verify/mirrorlist.yml
+++ b/ansible/roles/reflector/molecule/shared/verify/mirrorlist.yml
@@ -1,0 +1,36 @@
+---
+- name: Stat mirrorlist
+  ansible.builtin.stat:
+    path: "{{ reflector_mirrorlist_path }}"
+  register: _reflector_verify_mirrorlist
+
+- name: Assert mirrorlist exists with content
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_mirrorlist.stat.exists
+      - _reflector_verify_mirrorlist.stat.isreg
+      - _reflector_verify_mirrorlist.stat.size > 0
+    fail_msg: "{{ reflector_mirrorlist_path }} missing or empty"
+
+- name: Assert mirrorlist was generated after reflector config
+  ansible.builtin.assert:
+    that:
+      - (_reflector_verify_mirrorlist.stat.mtime | int) >= (_reflector_verify_conf_stat.stat.mtime | int)
+    fail_msg: >-
+      {{ reflector_mirrorlist_path }} is older than {{ reflector_conf_path }};
+      update may have been skipped after config changed.
+
+- name: Read mirrorlist content
+  ansible.builtin.slurp:
+    src: "{{ reflector_mirrorlist_path }}"
+  register: _reflector_verify_mirrorlist_raw
+
+- name: Decode mirrorlist content
+  ansible.builtin.set_fact:
+    _reflector_verify_mirrorlist_text: "{{ _reflector_verify_mirrorlist_raw.content | b64decode }}"
+
+- name: Assert mirrorlist contains active pacman servers
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_mirrorlist_text is regex('(?m)^Server = ')
+    fail_msg: "{{ reflector_mirrorlist_path }} does not contain any Server entries"

--- a/ansible/roles/reflector/molecule/shared/verify/package.yml
+++ b/ansible/roles/reflector/molecule/shared/verify/package.yml
@@ -1,0 +1,10 @@
+---
+- name: Gather package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Assert reflector package is installed
+  ansible.builtin.assert:
+    that:
+      - "'reflector' in ansible_facts.packages"
+    fail_msg: "reflector package not found"

--- a/ansible/roles/reflector/molecule/shared/verify/timer.yml
+++ b/ansible/roles/reflector/molecule/shared/verify/timer.yml
@@ -1,0 +1,45 @@
+---
+- name: Stat timer drop-in
+  ansible.builtin.stat:
+    path: /etc/systemd/system/reflector.timer.d/override.conf
+  register: _reflector_verify_dropin_stat
+
+- name: Assert timer drop-in exists
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_dropin_stat.stat.exists
+      - _reflector_verify_dropin_stat.stat.isreg
+    fail_msg: "Timer drop-in /etc/systemd/system/reflector.timer.d/override.conf missing"
+
+- name: Read timer drop-in content
+  ansible.builtin.slurp:
+    src: /etc/systemd/system/reflector.timer.d/override.conf
+  register: _reflector_verify_dropin_raw
+
+- name: Decode timer drop-in content
+  ansible.builtin.set_fact:
+    _reflector_verify_dropin_text: "{{ _reflector_verify_dropin_raw.content | b64decode }}"
+
+- name: Assert timer drop-in contains expected values
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_dropin_text is regex('OnCalendar=' ~ reflector_timer_schedule)
+      - _reflector_verify_dropin_text is regex('RandomizedDelaySec=' ~ reflector_timer_randomized_delay)
+    fail_msg: "Timer drop-in missing OnCalendar or RandomizedDelaySec"
+
+- name: Gather reflector.timer systemd state
+  ansible.builtin.systemd_service:
+    name: reflector.timer
+  check_mode: true
+  register: _reflector_verify_timer
+  changed_when: false
+
+- name: Assert reflector.timer is enabled
+  ansible.builtin.assert:
+    that:
+      - _reflector_verify_timer.status.UnitFileState is defined
+      - _reflector_verify_timer.status.UnitFileState == 'enabled'
+    fail_msg: >-
+      reflector.timer is not enabled
+      (UnitFileState:
+      {{ _reflector_verify_timer.status.UnitFileState | default('missing') }})

--- a/ansible/roles/reflector/molecule/vagrant/molecule.yml
+++ b/ansible/roles/reflector/molecule/vagrant/molecule.yml
@@ -28,6 +28,7 @@ provisioner:
   playbooks:
     prepare: prepare.yml
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
 
 verifier:
@@ -39,5 +40,7 @@ scenario:
     - create
     - prepare
     - converge
+    - idempotence
+    - side_effect
     - verify
     - destroy

--- a/ansible/roles/reflector/molecule/vagrant/side_effect.yml
+++ b/ansible/roles/reflector/molecule/vagrant/side_effect.yml
@@ -1,0 +1,59 @@
+---
+- name: Verify reflector check mode does not mutate mirrorlist state
+  hosts: all
+  become: true
+  gather_facts: true
+  vars_files:
+    - ../../defaults/main.yml
+
+  tasks:
+    - name: Skip check-mode side effect on non-Arch systems
+      ansible.builtin.meta: end_host
+      when: ansible_facts['os_family'] != 'Archlinux'
+
+    - name: Stat mirrorlist before check mode
+      ansible.builtin.stat:
+        path: "{{ reflector_mirrorlist_path }}"
+        checksum_algorithm: sha256
+      register: _reflector_check_mirrorlist_before
+
+    - name: Count backups before check mode
+      ansible.builtin.find:
+        paths: "{{ reflector_mirrorlist_path | dirname }}"
+        patterns: "{{ reflector_mirrorlist_path | basename }}.bak.*"
+      register: _reflector_check_backups_before
+      when: reflector_backup_mirrorlist | bool
+
+    - name: Run reflector role in check mode
+      ansible.builtin.include_role:
+        name: reflector
+        apply:
+          check_mode: true
+
+    - name: Stat mirrorlist after check mode
+      ansible.builtin.stat:
+        path: "{{ reflector_mirrorlist_path }}"
+        checksum_algorithm: sha256
+      register: _reflector_check_mirrorlist_after
+
+    - name: Count backups after check mode
+      ansible.builtin.find:
+        paths: "{{ reflector_mirrorlist_path | dirname }}"
+        patterns: "{{ reflector_mirrorlist_path | basename }}.bak.*"
+      register: _reflector_check_backups_after
+      when: reflector_backup_mirrorlist | bool
+
+    - name: Assert check mode did not mutate mirrorlist
+      ansible.builtin.assert:
+        that:
+          - _reflector_check_mirrorlist_before.stat.exists
+          - _reflector_check_mirrorlist_after.stat.exists
+          - _reflector_check_mirrorlist_before.stat.checksum == _reflector_check_mirrorlist_after.stat.checksum
+        fail_msg: "{{ reflector_mirrorlist_path }} changed during check mode"
+
+    - name: Assert check mode did not create or remove backups
+      ansible.builtin.assert:
+        that:
+          - _reflector_check_backups_before.matched == _reflector_check_backups_after.matched
+        fail_msg: "Mirrorlist backup count changed during check mode"
+      when: reflector_backup_mirrorlist | bool

--- a/ansible/roles/reflector/tasks/update.yml
+++ b/ansible/roles/reflector/tasks/update.yml
@@ -1,157 +1,22 @@
 ---
-- name: Find pacman sync databases
-  ansible.builtin.find:
-    paths: /var/lib/pacman/sync
-    patterns: "*.db"
-    file_type: file
-  register: reflector_pacman_sync_db
+- name: Inspect mirrorlist update state
+  ansible.builtin.import_tasks: update/preflight.yml
   tags: ['update']
 
-- name: Decide whether pacman cache refresh is required
-  ansible.builtin.set_fact:
-    reflector_pacman_cache_refresh_required: >-
-      {{
-        (reflector_pacman_sync_db.matched | default(0) | int) == 0 or
-        (
-          ansible_facts['date_time']['epoch'] | int -
-          ((reflector_pacman_sync_db.files | map(attribute='mtime') | max | default(0)) | int)
-        ) >= (reflector_pacman_cache_valid_time | int)
-      }}
-  changed_when: false
-  tags: ['update']
-
-- name: Update pacman cache
-  community.general.pacman:
-    update_cache: true
-  when: reflector_pacman_cache_refresh_required | bool
-  tags: ['update']
-
-- name: Stat current mirrorlist
-  ansible.builtin.stat:
-    path: "{{ reflector_mirrorlist_path }}"
-  register: reflector_stat
-  tags: ['update']
-
-- name: Check if mirrorlist is recent (skip if updated within 1h)
-  ansible.builtin.set_fact:
-    _reflector_skip: >-
-      {{
-        reflector_stat.stat.exists and
-        (ansible_facts['date_time']['epoch'] | int - reflector_stat.stat.mtime | int) < 3600
-      }}
-  tags: ['update']
-
-- name: Read current mirrorlist (for change comparison)
-  ansible.builtin.slurp:
-    src: "{{ reflector_mirrorlist_path }}"
-  register: reflector_old_mirror
-  when: reflector_stat.stat.exists
-  tags: ['update']
-
-- name: Backup current mirrorlist BEFORE update
-  ansible.builtin.copy:
-    remote_src: true
-    src: "{{ reflector_mirrorlist_path }}"
-    dest: "{{ reflector_mirrorlist_path }}.bak.{{ ansible_facts['date_time']['iso8601_basic'] }}"
-    mode: '0644'
-  register: reflector_backup_result
+- name: Report mirrorlist update skipped in check mode
+  ansible.builtin.debug:
+    msg: >-
+      Reflector mirrorlist update would run, but check mode is active.
+      Skipping network update and mirrorlist mutation.
+  changed_when: true
   when:
-    - reflector_backup_mirrorlist | bool
-    - reflector_stat.stat.exists
+    - ansible_check_mode
     - not (_reflector_skip | bool)
   tags: ['update']
 
-- name: Record backup path as fact
-  ansible.builtin.set_fact:
-    reflector_latest_backup: "{{ reflector_backup_result.dest }}"
+- name: Update mirrorlist when required
+  ansible.builtin.import_tasks: update/run.yml
   when:
-    - reflector_backup_result is not skipped
+    - not ansible_check_mode
     - not (_reflector_skip | bool)
   tags: ['update']
-
-- name: Run reflector and validate mirrorlist
-  tags: ['update']
-  when: not (_reflector_skip | bool)
-  block:
-    - name: Run reflector to update mirrorlist (with retries)
-      ansible.builtin.command: >-
-        reflector
-        --country {{ reflector_countries }}
-        --protocol {{ reflector_protocol }}
-        --latest {{ reflector_latest }}
-        --sort {{ reflector_sort }}
-        --age {{ reflector_age }}
-        --connection-timeout {{ reflector_connection_timeout }}
-        --download-timeout {{ reflector_download_timeout }}
-        --threads {{ reflector_threads }}
-        --save {{ reflector_mirrorlist_path }}
-      register: reflector_run
-      retries: "{{ reflector_retries }}"
-      delay: "{{ reflector_retry_delay }}"
-      until: reflector_run.rc == 0
-      changed_when: false
-      failed_when: reflector_run.rc != 0
-      check_mode: false
-      environment: "{{ {'http_proxy': reflector_proxy, 'https_proxy': reflector_proxy} if reflector_proxy | length > 0 else {} }}"
-
-    - name: Read new mirrorlist
-      ansible.builtin.slurp:
-        src: "{{ reflector_mirrorlist_path }}"
-      register: reflector_new_mirror
-
-    - name: Validate mirrorlist contains Server entries
-      ansible.builtin.command:
-        cmd: grep -c '^Server = ' {{ reflector_mirrorlist_path }}
-      register: reflector_server_count
-      changed_when: false
-      failed_when: reflector_server_count.stdout | int < 1
-
-    - name: Find old mirrorlist backups for rotation
-      ansible.builtin.find:
-        paths: "{{ reflector_mirrorlist_path | dirname }}"
-        patterns: "mirrorlist.bak.*"
-      register: _reflector_backups
-      when:
-        - reflector_backup_mirrorlist | bool
-        - reflector_backup_keep | int > 0
-
-    - name: Remove oldest backups, keep N newest
-      ansible.builtin.file:
-        path: "{{ item.path }}"
-        state: absent
-      loop: "{{ (_reflector_backups.files | sort(attribute='mtime'))[: -reflector_backup_keep | int] }}"
-      when:
-        - reflector_backup_mirrorlist | bool
-        - reflector_backup_keep | int > 0
-        - _reflector_backups.matched > reflector_backup_keep | int
-
-    - name: Determine if mirrorlist changed
-      ansible.builtin.set_fact:
-        reflector_mirrorlist_changed: >-
-          {{ (reflector_old_mirror.content | default('')) != (reflector_new_mirror.content | default('')) }}
-
-    - name: Report reflector result
-      ansible.builtin.debug:
-        msg: >-
-          Reflector completed. Mirrorlist changed: {{ reflector_mirrorlist_changed }}.
-          Servers in mirrorlist: {{ reflector_server_count.stdout }}.
-      changed_when: reflector_mirrorlist_changed | bool
-
-  rescue:
-    - name: Restore mirrorlist from backup
-      ansible.builtin.copy:
-        remote_src: true
-        src: "{{ reflector_latest_backup }}"
-        dest: "{{ reflector_mirrorlist_path }}"
-        mode: '0644'
-      when: reflector_latest_backup is defined
-
-    - name: Fail with descriptive message
-      ansible.builtin.fail:
-        msg: >-
-          reflector failed or produced an invalid mirrorlist.
-          {% if reflector_latest_backup is defined %}
-          Restored from {{ reflector_latest_backup }}.
-          {% else %}
-          No backup was available — mirrorlist may be empty or missing.
-          {% endif %}

--- a/ansible/roles/reflector/tasks/update/apply.yml
+++ b/ansible/roles/reflector/tasks/update/apply.yml
@@ -1,0 +1,54 @@
+---
+- name: Run reflector to update mirrorlist
+  ansible.builtin.command:
+    argv:
+      - reflector
+      - --country
+      - "{{ reflector_countries }}"
+      - --protocol
+      - "{{ reflector_protocol }}"
+      - --latest
+      - "{{ reflector_latest | string }}"
+      - --sort
+      - "{{ reflector_sort }}"
+      - --age
+      - "{{ reflector_age | string }}"
+      - --connection-timeout
+      - "{{ reflector_connection_timeout | string }}"
+      - --download-timeout
+      - "{{ reflector_download_timeout | string }}"
+      - --threads
+      - "{{ reflector_threads | string }}"
+      - --save
+      - "{{ reflector_mirrorlist_path }}"
+  register: reflector_run
+  retries: "{{ reflector_retries }}"
+  delay: "{{ reflector_retry_delay }}"
+  until: reflector_run.rc == 0
+  changed_when: false
+  failed_when: reflector_run.rc != 0
+  environment: >-
+    {{
+      {'http_proxy': reflector_proxy, 'https_proxy': reflector_proxy}
+      if reflector_proxy | length > 0
+      else {}
+    }}
+  tags: ['update']
+
+- name: Read new mirrorlist
+  ansible.builtin.slurp:
+    src: "{{ reflector_mirrorlist_path }}"
+  register: reflector_new_mirror
+  tags: ['update']
+
+- name: Decode new mirrorlist
+  ansible.builtin.set_fact:
+    _reflector_new_mirror_text: "{{ reflector_new_mirror.content | b64decode }}"
+  tags: ['update']
+
+- name: Assert generated mirrorlist has active pacman servers
+  ansible.builtin.assert:
+    that:
+      - _reflector_new_mirror_text is regex('(?m)^Server = ')
+    fail_msg: "{{ reflector_mirrorlist_path }} does not contain any Server entries"
+  tags: ['update']

--- a/ansible/roles/reflector/tasks/update/backup.yml
+++ b/ansible/roles/reflector/tasks/update/backup.yml
@@ -1,0 +1,25 @@
+---
+- name: Read current mirrorlist for change comparison
+  ansible.builtin.slurp:
+    src: "{{ reflector_mirrorlist_path }}"
+  register: reflector_old_mirror
+  when: reflector_stat.stat.exists
+  tags: ['update']
+
+- name: Backup current mirrorlist before update
+  ansible.builtin.copy:
+    remote_src: true
+    src: "{{ reflector_mirrorlist_path }}"
+    dest: "{{ reflector_mirrorlist_path }}.bak.{{ ansible_facts['date_time']['iso8601_basic'] }}"
+    mode: '0644'
+  register: reflector_backup_result
+  when:
+    - reflector_backup_mirrorlist | bool
+    - reflector_stat.stat.exists
+  tags: ['update']
+
+- name: Record backup path as fact
+  ansible.builtin.set_fact:
+    reflector_latest_backup: "{{ reflector_backup_result.dest }}"
+  when: reflector_backup_result is not skipped
+  tags: ['update']

--- a/ansible/roles/reflector/tasks/update/preflight.yml
+++ b/ansible/roles/reflector/tasks/update/preflight.yml
@@ -1,0 +1,28 @@
+---
+- name: Stat current mirrorlist
+  ansible.builtin.stat:
+    path: "{{ reflector_mirrorlist_path }}"
+  register: reflector_stat
+  tags: ['update']
+
+- name: Stat reflector config
+  ansible.builtin.stat:
+    path: "{{ reflector_conf_path }}"
+  register: reflector_config_stat
+  tags: ['update']
+
+- name: Decide whether mirrorlist update can be skipped
+  ansible.builtin.set_fact:
+    _reflector_skip: >-
+      {{
+        reflector_stat.stat.exists
+        and (
+          (ansible_facts['date_time']['epoch'] | int)
+          - (reflector_stat.stat.mtime | int)
+        ) < (reflector_update_min_interval | int)
+        and (
+          not reflector_config_stat.stat.exists
+          or (reflector_stat.stat.mtime | int) >= (reflector_config_stat.stat.mtime | int)
+        )
+      }}
+  tags: ['update']

--- a/ansible/roles/reflector/tasks/update/report.yml
+++ b/ansible/roles/reflector/tasks/update/report.yml
@@ -1,0 +1,13 @@
+---
+- name: Determine if mirrorlist changed
+  ansible.builtin.set_fact:
+    reflector_mirrorlist_changed: >-
+      {{ (reflector_old_mirror.content | default('')) != (reflector_new_mirror.content | default('')) }}
+  tags: ['update']
+
+- name: Report reflector result
+  ansible.builtin.debug:
+    msg: >-
+      Reflector completed. Mirrorlist changed: {{ reflector_mirrorlist_changed }}.
+  changed_when: reflector_mirrorlist_changed | bool
+  tags: ['update']

--- a/ansible/roles/reflector/tasks/update/rotate-backups.yml
+++ b/ansible/roles/reflector/tasks/update/rotate-backups.yml
@@ -1,0 +1,33 @@
+---
+- name: Find old mirrorlist backups for rotation
+  ansible.builtin.find:
+    paths: "{{ reflector_mirrorlist_path | dirname }}"
+    patterns: "{{ reflector_mirrorlist_path | basename }}.bak.*"
+  register: _reflector_backups
+  when:
+    - reflector_backup_mirrorlist | bool
+    - reflector_backup_keep | int > 0
+  tags: ['update']
+
+- name: Calculate mirrorlist backups to remove
+  ansible.builtin.set_fact:
+    _reflector_backup_remove_count: "{{ [((_reflector_backups.matched | default(0) | int) - (reflector_backup_keep | int)), 0] | max }}"
+  when:
+    - reflector_backup_mirrorlist | bool
+    - reflector_backup_keep | int > 0
+  tags: ['update']
+
+- name: Remove oldest backups, keep configured count
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ (_reflector_backups.files | default([])) | sort(attribute='mtime') }}"
+  loop_control:
+    label: "{{ item.path }}"
+    index_var: _reflector_backup_index
+  when:
+    - reflector_backup_mirrorlist | bool
+    - reflector_backup_keep | int > 0
+    - _reflector_backup_remove_count | default(0) | int > 0
+    - _reflector_backup_index < (_reflector_backup_remove_count | int)
+  tags: ['update']

--- a/ansible/roles/reflector/tasks/update/run.yml
+++ b/ansible/roles/reflector/tasks/update/run.yml
@@ -1,0 +1,35 @@
+---
+- name: Prepare mirrorlist backup
+  ansible.builtin.import_tasks: update/backup.yml
+  tags: ['update']
+
+- name: Run reflector update with rollback
+  tags: ['update']
+  block:
+    - name: Apply reflector mirrorlist update
+      ansible.builtin.import_tasks: update/apply.yml
+
+    - name: Rotate old mirrorlist backups
+      ansible.builtin.import_tasks: update/rotate-backups.yml
+
+    - name: Report mirrorlist update result
+      ansible.builtin.import_tasks: update/report.yml
+
+  rescue:
+    - name: Restore mirrorlist from backup
+      ansible.builtin.copy:
+        remote_src: true
+        src: "{{ reflector_latest_backup }}"
+        dest: "{{ reflector_mirrorlist_path }}"
+        mode: '0644'
+      when: reflector_latest_backup is defined
+
+    - name: Fail with descriptive message
+      ansible.builtin.fail:
+        msg: >-
+          reflector failed or produced an invalid mirrorlist.
+          {% if reflector_latest_backup is defined %}
+          Restored from {{ reflector_latest_backup }}.
+          {% else %}
+          No backup was available - mirrorlist may be empty or missing.
+          {% endif %}


### PR DESCRIPTION
## Summary
- remove the misplaced pacman cache refresh from the reflector update path
- split reflector update into preflight, backup, apply, rotation, and report task files with check-mode guardrails
- decompose Molecule verification into offline/full contracts and add Vagrant idempotence/check-mode non-mutation coverage

## Validation
- `git diff --staged --check` before commit
- scoped staging check: only `ansible/roles/reflector/**` was committed
- not run: Ansible/Molecule VM checks, because project policy requires the remote VM/Taskfile workflow for those runs

## Notes
- left unrelated local LFS change unstaged: `dotfiles/wallpapers/military 1.png`
- PR targets the stacked base branch `fix/boot-016-system-update-reboot-before-workstation` so the diff stays focused on reflector changes
