### PR TITLE
fix(docker): verify userns-remap secure default

### DIFF
--- a/ansible/roles/caddy/molecule/shared/converge.yml
+++ b/ansible/roles/caddy/molecule/shared/converge.yml
@@ -6,9 +6,7 @@
 
   vars:
     # Docker role overrides for molecule VMs:
-    # - userns-remap requires subuid/subgid entries not present in fresh VMs
     # - journald log driver is incompatible with max-size/max-file log-opts
-    docker_userns_remap: ""
     docker_log_driver: "json-file"
 
   roles:

--- a/ansible/roles/caddy/molecule/vagrant/molecule.yml
+++ b/ansible/roles/caddy/molecule/vagrant/molecule.yml
@@ -32,10 +32,6 @@ provisioner:
         # edge-case play) so the docker dependency doesn't rewrite daemon.json
         # with incompatible defaults on the second role invocation.
         docker_log_driver: "json-file"
-        docker_userns_remap: ""
-        docker_icc: true
-        docker_live_restore: false
-        docker_no_new_privileges: false
     host_vars:
       arch-vm:
         docker_storage_driver: "btrfs"

--- a/ansible/roles/docker/README.md
+++ b/ansible/roles/docker/README.md
@@ -87,14 +87,18 @@ docker_log_max_file: "5"
 - `journald` (default) -- logs go to systemd journal, searchable via `journalctl CONTAINER_NAME=...`
 - `json-file` -- logs stored as JSON files in `/var/lib/docker/containers/<id>/`, rotated by `max-size`/`max-file`
 
-### Disabling security hardening for development
+### Disabling security hardening for an explicit exception
 
 ```yaml
-# In host_vars/<dev-workstation>/docker.yml:
+# In host_vars/<workstation>/docker.yml, only after accepting the trade-off:
 docker_userns_remap: ""          # disable user namespace remapping
 docker_icc: true                 # allow inter-container communication
 docker_no_new_privileges: false  # allow setuid in containers
 ```
+
+The default remains `docker_userns_remap: "default"` for all workstation
+profiles. Writable bind mounts are the usual reason to disable it; prefer
+named volumes or read-only host mounts instead.
 
 ### Adding custom daemon.json settings
 

--- a/ansible/roles/docker/defaults/main.yml
+++ b/ansible/roles/docker/defaults/main.yml
@@ -58,9 +58,9 @@ docker_storage_supported_drivers:
 # CIS 2.8 — Enable user namespace support (userns-remap)
 # WARNING: userns-remap ломает volume permissions — используйте named volumes
 # или chown 100000:100000 на хосте. Подробности: https://docs.docker.com/engine/security/userns-remap/
-# Profile: developer relaxes this (empty string disables)
-docker_userns_remap: >-
-  {{ '' if 'developer' in (workstation_profiles | default([])) else 'default' }}
+# Keep this enabled by default for every workstation profile. Disable only with
+# an explicit host override after accepting the bind-mount ownership trade-off.
+docker_userns_remap: "default"
 
 # CIS 2.1 — Restrict network traffic between containers (icc)
 # ICC false блокирует прямое общение контейнеров через docker0.

--- a/ansible/roles/docker/molecule/default/molecule.yml
+++ b/ansible/roles/docker/molecule/default/molecule.yml
@@ -24,6 +24,7 @@ provisioner:
       localhost:
         ansible_connection: local
         ansible_become_password: "{{ lookup('ansible.builtin.env', 'BOOTSTRAP_SUDO_PASSWORD') }}"
+        docker_test_runtime_smoke_enabled: true
   playbooks:
     converge: converge.yml
     verify: verify.yml

--- a/ansible/roles/docker/molecule/shared/verify/runtime_smoke.yml
+++ b/ansible/roles/docker/molecule/shared/verify/runtime_smoke.yml
@@ -34,6 +34,82 @@
       {{ _docker_runtime_process_smoke.stderr | default('') }}
     success_msg: "Docker process smoke passed"
 
+- name: Verify Docker user namespace remap behavior
+  when: docker_userns_remap | string | trim | length > 0
+  block:
+    - name: Remove stale Docker userns smoke container
+      ansible.builtin.command:
+        argv:
+          - docker
+          - rm
+          - -f
+          - bootstrap-docker-userns-smoke
+      changed_when: false
+      failed_when: false
+
+    - name: Start Docker userns smoke container
+      ansible.builtin.command:
+        argv:
+          - docker
+          - run
+          - -d
+          - --name
+          - bootstrap-docker-userns-smoke
+          - "{{ docker_test_runtime_smoke_image | default('busybox:latest') }}"
+          - sleep
+          - "60"
+      register: _docker_userns_smoke_container
+      changed_when: false
+      failed_when: _docker_userns_smoke_container.rc != 0
+
+    - name: Inspect Docker userns smoke container PID
+      ansible.builtin.command:
+        argv:
+          - docker
+          - inspect
+          - --format
+          - "{{ '{{' }}.State.Pid{{ '}}' }}"
+          - bootstrap-docker-userns-smoke
+      register: _docker_userns_smoke_pid
+      changed_when: false
+      failed_when:
+        - _docker_userns_smoke_pid.rc != 0
+          or (_docker_userns_smoke_pid.stdout | trim | int) <= 0
+
+    - name: Read host UID for Docker userns smoke process
+      ansible.builtin.command:
+        argv:
+          - ps
+          - -o
+          - uid=
+          - -p
+          - "{{ _docker_userns_smoke_pid.stdout | trim }}"
+      register: _docker_userns_smoke_host_uid
+      changed_when: false
+      failed_when: _docker_userns_smoke_host_uid.rc != 0
+
+    - name: Assert Docker userns remaps container root away from host root
+      ansible.builtin.assert:
+        that:
+          - (_docker_userns_smoke_host_uid.stdout | trim) != '0'
+        fail_msg: >-
+          Docker userns-remap is configured but the container process is still
+          running as host UID 0. Host UID:
+          {{ _docker_userns_smoke_host_uid.stdout | default('UNKNOWN') }}.
+        success_msg: >-
+          Docker userns-remap is active: container root process maps to host
+          UID {{ _docker_userns_smoke_host_uid.stdout | trim }}.
+  always:
+    - name: Clean Docker userns smoke container
+      ansible.builtin.command:
+        argv:
+          - docker
+          - rm
+          - -f
+          - bootstrap-docker-userns-smoke
+      changed_when: false
+      failed_when: false
+
 - name: Create Docker storage smoke volume
   ansible.builtin.command:
     argv:
@@ -85,47 +161,6 @@
       {{ _docker_runtime_volume_read.stderr | default('') }}
     success_msg: "Docker named volume smoke passed"
 
-- name: Ensure Docker bind smoke directory exists
-  ansible.builtin.file:
-    path: /tmp/bootstrap-docker-bind-smoke
-    state: directory
-    mode: '0755'
-
-- name: Write through Docker bind mount
-  ansible.builtin.command:
-    argv:
-      - docker
-      - run
-      - --rm
-      - -v
-      - /tmp/bootstrap-docker-bind-smoke:/data
-      - "{{ docker_test_runtime_smoke_image | default('busybox:latest') }}"
-      - sh
-      - -c
-      - "printf bind-ok > /data/probe"
-  register: _docker_runtime_bind_write
-  changed_when: false
-  failed_when: _docker_runtime_bind_write.rc != 0
-
-- name: Read Docker bind mount result
-  ansible.builtin.command:
-    argv:
-      - cat
-      - /tmp/bootstrap-docker-bind-smoke/probe
-  register: _docker_runtime_bind_read
-  changed_when: false
-  failed_when: _docker_runtime_bind_read.rc != 0
-
-- name: Assert Docker bind mount smoke worked
-  ansible.builtin.assert:
-    that:
-      - _docker_runtime_bind_read.stdout | trim == 'bind-ok'
-    fail_msg: >-
-      Docker bind mount smoke failed:
-      {{ _docker_runtime_bind_read.stdout | default('') }}
-      {{ _docker_runtime_bind_read.stderr | default('') }}
-    success_msg: "Docker bind mount smoke passed"
-
 - name: Clean Docker storage smoke volume
   ansible.builtin.command:
     argv:
@@ -136,8 +171,3 @@
       - bootstrap-docker-storage-smoke
   changed_when: false
   failed_when: false
-
-- name: Clean Docker bind smoke directory
-  ansible.builtin.file:
-    path: /tmp/bootstrap-docker-bind-smoke
-    state: absent

--- a/ansible/roles/docker/molecule/vagrant/molecule.yml
+++ b/ansible/roles/docker/molecule/vagrant/molecule.yml
@@ -36,18 +36,10 @@ provisioner:
         docker_test_runtime_smoke_enabled: true
     host_vars:
       arch-vm:
-        docker_userns_remap: ""
-        docker_icc: true
         docker_log_driver: "json-file"
-        docker_live_restore: false
-        docker_no_new_privileges: false
         docker_storage_driver: "btrfs"
       ubuntu-base:
-        docker_userns_remap: ""
-        docker_icc: true
         docker_log_driver: "json-file"
-        docker_live_restore: false
-        docker_no_new_privileges: false
   playbooks:
     prepare: prepare.yml
     converge: converge.yml

--- a/ansible/roles/docker/tasks/verify_runtime.yml
+++ b/ansible/roles/docker/tasks/verify_runtime.yml
@@ -1,6 +1,69 @@
 ---
 # Runtime check that requires a running Docker daemon.
 
+- name: Lookup Docker userns-remap user
+  vars:
+    _docker_userns_remap_value: "{{ docker_userns_remap | string | trim }}"
+    _docker_userns_remap_user: >-
+      {{ 'dockremap' if _docker_userns_remap_value == 'default'
+         else _docker_userns_remap_value.split(':')[0] }}
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ _docker_userns_remap_user }}"
+  register: _docker_userns_remap_passwd
+  failed_when: false
+  when: docker_userns_remap | string | trim | length > 0
+
+- name: Assert Docker userns-remap user exists
+  vars:
+    _docker_userns_remap_value: "{{ docker_userns_remap | string | trim }}"
+    _docker_userns_remap_user: >-
+      {{ 'dockremap' if _docker_userns_remap_value == 'default'
+         else _docker_userns_remap_value.split(':')[0] }}
+  ansible.builtin.assert:
+    that:
+      - "(_docker_userns_remap_passwd.ansible_facts.getent_passwd | default({}))[_docker_userns_remap_user] is defined"
+    fail_msg: >-
+      Docker userns-remap is enabled ({{ _docker_userns_remap_value }}) but
+      remap user '{{ _docker_userns_remap_user }}' does not exist.
+    success_msg: >-
+      Docker userns-remap user '{{ _docker_userns_remap_user }}' exists.
+  when: docker_userns_remap | string | trim | length > 0
+
+- name: Verify Docker userns-remap subordinate UID range
+  vars:
+    _docker_userns_remap_value: "{{ docker_userns_remap | string | trim }}"
+    _docker_userns_remap_user: >-
+      {{ 'dockremap' if _docker_userns_remap_value == 'default'
+         else _docker_userns_remap_value.split(':')[0] }}
+  ansible.builtin.command:
+    argv:
+      - grep
+      - -E
+      - "^{{ _docker_userns_remap_user }}:"
+      - /etc/subuid
+  register: _docker_userns_subuid
+  changed_when: false
+  failed_when: _docker_userns_subuid.rc != 0
+  when: docker_userns_remap | string | trim | length > 0
+
+- name: Verify Docker userns-remap subordinate GID range
+  vars:
+    _docker_userns_remap_value: "{{ docker_userns_remap | string | trim }}"
+    _docker_userns_remap_user: >-
+      {{ 'dockremap' if _docker_userns_remap_value == 'default'
+         else _docker_userns_remap_value.split(':')[0] }}
+  ansible.builtin.command:
+    argv:
+      - grep
+      - -E
+      - "^{{ _docker_userns_remap_user }}:"
+      - /etc/subgid
+  register: _docker_userns_subgid
+  changed_when: false
+  failed_when: _docker_userns_subgid.rc != 0
+  when: docker_userns_remap | string | trim | length > 0
+
 - name: Get docker info
   ansible.builtin.command: "docker info --format '{{ '{{' }}json .{{ '}}' }}'"
   register: _docker_verify_info_raw
@@ -14,10 +77,15 @@
   ansible.builtin.assert:
     that:
       - "_docker_runtime_info['Driver'] == _docker_storage_driver"
+      - >-
+        docker_userns_remap | string | trim | length == 0
+        or 'userns' in (_docker_runtime_info['SecurityOptions'] | default([]) | join(','))
     fail_msg: >-
-      Docker runtime storage driver mismatch:
-      expected '{{ _docker_storage_driver }}',
-      got '{{ _docker_runtime_info['Driver'] | default('UNKNOWN') }}'.
+      Docker runtime mismatch:
+      expected storage driver '{{ _docker_storage_driver }}'
+      and userns security option when docker_userns_remap is enabled.
+      Runtime info: {{ _docker_runtime_info }}.
     success_msg: >-
-      Docker runtime storage driver matches:
-      {{ _docker_runtime_info['Driver'] }}.
+      Docker runtime matches core contract:
+      driver={{ _docker_runtime_info['Driver'] }},
+      security={{ _docker_runtime_info['SecurityOptions'] | default([]) }}.

--- a/ansible/roles/vaultwarden/molecule/vagrant/molecule.yml
+++ b/ansible/roles/vaultwarden/molecule/vagrant/molecule.yml
@@ -26,15 +26,8 @@ provisioner:
         caddy_enabled: false
         # Handlers skip: containers not started (molecule-notest).
         vaultwarden_compose_manage: false
-        # CI-safe docker overrides: journald log-driver with max-size/
-        # max-file log-opts is invalid (those opts are json-file only).
-        # CIS defaults (userns-remap, icc, no-new-privileges) also need
-        # user namespaces which are not available in Vagrant CI VMs.
+        # CI-safe docker override: use json-file in Vagrant fixtures.
         docker_log_driver: "json-file"
-        docker_userns_remap: ""
-        docker_icc: true
-        docker_live_restore: false
-        docker_no_new_privileges: false
     host_vars:
       arch-vm:
         docker_storage_driver: "btrfs"

--- a/wiki/standards/workstation-profiles.md
+++ b/wiki/standards/workstation-profiles.md
@@ -94,7 +94,7 @@ In Jinja2 expressions this translates to a cascade of `if` checks, evaluated fro
 | Kernel      | `ptrace_scope: 1`                                              | Allows `gdb ./app`, `strace -p`, debugger attach to child processes |
 | Kernel      | `perf_event_paranoid: 1`                                       | Enables `perf record`, `perf stat` without root  |
 | Docker      | `icc: true`                                                    | Container-to-container communication for microservice development on docker0 bridge |
-| Docker      | `userns-remap: ""`                                             | Avoids volume permission issues during active development; named volumes recommended in production |
+| Docker      | `userns-remap: default`                                        | Keep container root remapped away from host root; prefer named volumes or read-only host mounts |
 | SSH         | `MaxStartups: 10:30:60`                                        | VS Code Remote SSH + multiple terminal sessions  |
 | Network     | No additional firewall changes                                 | Outbound is already unrestricted                 |
 | Shell       | Dev-oriented prompt, git integration, language version managers | Enhanced developer ergonomics                    |
@@ -112,7 +112,7 @@ In Jinja2 expressions this translates to a cascade of `if` checks, evaluated fro
 | CPU         | `performance` governor                                         | Maximum clock speed; no frequency scaling latency |
 | GPU         | Power saving disabled                                          | Prevents GPU downclocking mid-frame              |
 | Docker      | `no-new-privileges: false`                                     | Some game servers and Wine prefixes require setuid helpers |
-| Docker      | `userns-remap: ""`                                             | Compatibility with game server containers that bind-mount host directories |
+| Docker      | `userns-remap: default`                                        | Keep container root remapped away from host root; override only for a proven bind-mount requirement |
 | Audio       | Low-latency PipeWire configuration                             | Reduces audio crackle during high CPU load       |
 | Network     | Standard rate limiting preserved                               | Gaming traffic is outbound; inbound SSH protection still applies |
 
@@ -260,7 +260,7 @@ Concrete values for each setting per active profile. When multiple profiles are 
 | Parameter            | base      | developer | gaming | media   | security  |
 |----------------------|-----------|-----------|--------|---------|-----------|
 | `icc`                | `false`   | `true`    | `false`| `false` | `false`   |
-| `userns-remap`       | `default` | `""`      | `""`   | `default` | `default` |
+| `userns-remap`       | `default` | `default` | `default` | `default` | `default` |
 | `no-new-privileges`  | `true`    | `true`    | `false`| `true`  | `true`    |
 | `live-restore`       | `true`    | `true`    | `true` | `true`  | `true`    |
 | `log-driver`         | `journald`| `journald`| `journald` | `journald` | `journald` |


### PR DESCRIPTION
## Summary

- keep Docker `userns-remap: default` as the secure default for all workstation profiles
- remove VM fixture overrides that disabled Docker userns hardening for Docker/Caddy/Vaultwarden scenarios
- add runtime verification that proves Docker actually starts with user namespaces and remaps container root away from host UID 0
- make the default Docker molecule scenario run behavior smoke checks for container execution, userns remap, and named volumes

Fixes #354.

## Validation

Executed on disposable VM `feature-boot-019-docker-userns-remap`, cloned from `arch-base@after-packages`, SSH port `2223`.

```text
SSH_HOST=arch-127.0.0.1-2223 bash scripts/ssh-run.sh --bootstrap-secrets "cd ~/bootstrap && task check"
Syntax check passed
```

```text
SSH_HOST=arch-127.0.0.1-2223 bash scripts/ssh-run.sh --bootstrap-secrets "cd ~/bootstrap && task lint"
Passed: 0 failure(s), 19 warning(s) in 939 files processed of 980 encountered.
```

```text
SSH_HOST=arch-127.0.0.1-2223 bash scripts/ssh-run.sh --bootstrap-secrets "cd ~/bootstrap && task test-docker"
INFO     Molecule executed 1 scenario (1 successful)
Docker runtime matches core contract: driver=overlay2, security=['name=seccomp,profile=builtin', 'name=userns', 'name=cgroupns', 'name=no-new-privileges'].
Docker userns-remap is active: container root process maps to host UID 100000.
Docker named volume smoke passed
```
