### PR TITLE
fix(system_update): stabilize OpenSSH after upgrade

### DIFF
--- a/ansible/roles/system_update/README.md
+++ b/ansible/roles/system_update/README.md
@@ -11,6 +11,9 @@ Performs a full operating-system package upgrade before workstation configuratio
 - It runs package transaction recovery as a generic post-upgrade phase.
 - On Arch Linux, the recovery backend must leave `pacman` unlocked and the
   pacman database consistent for the next workflow step.
+- On Arch Linux, if `openssh` changes during the full upgrade, the role
+  validates `sshd` and restarts `sshd.service` so new SSH connections use the
+  upgraded daemon and helper binaries consistently.
 - A reboot boundary is required after a successful run and before `task workstation`.
 
 ## Workflow
@@ -34,7 +37,7 @@ the `bootloader` role. It is not exposed as a standalone public Taskfile entry.
 
 | OS family | Status | Backend |
 |-----------|--------|---------|
-| Archlinux | implemented | upgrade backend: `pacman -Sy` → `archlinux-keyring` → `pacman -Su`; recovery backend: pacman transaction recovery |
+| Archlinux | implemented | upgrade backend: `pacman -Sy` → `archlinux-keyring` → `pacman -Su` → OpenSSH stabilization when needed; recovery backend: pacman transaction recovery |
 | Debian | blocked | fail-fast diagnostic |
 | RedHat | blocked | fail-fast diagnostic |
 | Void | blocked | fail-fast diagnostic |

--- a/ansible/roles/system_update/molecule/shared/converge.yml
+++ b/ansible/roles/system_update/molecule/shared/converge.yml
@@ -81,14 +81,22 @@
         that:
           - "'Refresh package databases (pacman -Sy)' in _system_update_test_arch_source"
           - "'Update archlinux-keyring before full upgrade' in _system_update_test_arch_source"
+          - "'Capture installed OpenSSH version before full upgrade' in _system_update_test_arch_source"
           - "'Full system upgrade (pacman -Su)' in _system_update_test_arch_source"
+          - "'Capture installed OpenSSH version after full upgrade' in _system_update_test_arch_source"
+          - "'Validate OpenSSH daemon configuration before restart' in _system_update_test_arch_source"
+          - "'Restart OpenSSH daemon after package upgrade' in _system_update_test_arch_source"
           - _system_update_test_arch_source.find('Refresh package databases (pacman -Sy)') < _system_update_test_arch_source.find('Update archlinux-keyring before full upgrade')
-          - _system_update_test_arch_source.find('Update archlinux-keyring before full upgrade') < _system_update_test_arch_source.find('Full system upgrade (pacman -Su)')
+          - _system_update_test_arch_source.find('Update archlinux-keyring before full upgrade') < _system_update_test_arch_source.find('Capture installed OpenSSH version before full upgrade')
+          - _system_update_test_arch_source.find('Capture installed OpenSSH version before full upgrade') < _system_update_test_arch_source.find('Full system upgrade (pacman -Su)')
+          - _system_update_test_arch_source.find('Full system upgrade (pacman -Su)') < _system_update_test_arch_source.find('Capture installed OpenSSH version after full upgrade')
+          - _system_update_test_arch_source.find('Capture installed OpenSSH version after full upgrade') < _system_update_test_arch_source.find('Validate OpenSSH daemon configuration before restart')
+          - _system_update_test_arch_source.find('Validate OpenSSH daemon configuration before restart') < _system_update_test_arch_source.find('Restart OpenSSH daemon after package upgrade')
           - "'package_transaction_recovery' not in _system_update_test_arch_source"
           - "'pacman_recovery' not in _system_update_test_arch_source"
           - "'upgrade: true' in _system_update_test_arch_source"
-        fail_msg: "Arch backend must run pacman cache refresh, keyring update, then full system upgrade."
-        success_msg: "Arch backend order is pacman -Sy -> archlinux-keyring -> pacman -Su, with recovery owned by generic flow."
+        fail_msg: "Arch backend must run pacman cache refresh, keyring update, full system upgrade, and OpenSSH post-upgrade stabilization."
+        success_msg: "Arch backend order is pacman -Sy -> archlinux-keyring -> pacman -Su -> OpenSSH stabilization, with recovery owned by generic flow."
 
     - name: Assert Arch backend recovery contract
       ansible.builtin.assert:

--- a/ansible/roles/system_update/tasks/archlinux.yml
+++ b/ansible/roles/system_update/tasks/archlinux.yml
@@ -18,6 +18,14 @@
   until: _system_update_arch_keyring is succeeded
   tags: ['system_update', 'upgrade', 'pacman', 'keyring']
 
+- name: "Arch Linux | Capture installed OpenSSH version before full upgrade"
+  ansible.builtin.command:
+    cmd: pacman -Q openssh
+  register: _system_update_arch_openssh_before
+  changed_when: false
+  failed_when: _system_update_arch_openssh_before.rc not in [0, 1]
+  tags: ['system_update', 'upgrade', 'pacman', 'ssh']
+
 - name: "Arch Linux | Full system upgrade (pacman -Su)"
   community.general.pacman:
     upgrade: true
@@ -26,3 +34,50 @@
   register: _system_update_arch_upgrade
   until: _system_update_arch_upgrade is succeeded
   tags: ['system_update', 'upgrade', 'pacman']
+
+- name: "Arch Linux | Capture installed OpenSSH version after full upgrade"
+  ansible.builtin.command:
+    cmd: pacman -Q openssh
+  register: _system_update_arch_openssh_after
+  changed_when: false
+  failed_when: _system_update_arch_openssh_after.rc not in [0, 1]
+  tags: ['system_update', 'upgrade', 'pacman', 'ssh']
+
+- name: "Arch Linux | Detect OpenSSH package upgrade"
+  ansible.builtin.set_fact:
+    _system_update_arch_openssh_upgraded: >-
+      {{
+        _system_update_arch_openssh_before.rc == 0
+        and _system_update_arch_openssh_after.rc == 0
+        and (
+          _system_update_arch_openssh_before.stdout | trim
+          != _system_update_arch_openssh_after.stdout | trim
+        )
+      }}
+  tags: ['system_update', 'upgrade', 'pacman', 'ssh']
+
+- name: "Arch Linux | Stabilize OpenSSH after package upgrade"
+  when:
+    - ansible_facts['service_mgr'] | default('') == 'systemd'
+    - _system_update_arch_openssh_upgraded | bool
+  tags: ['system_update', 'upgrade', 'pacman', 'ssh']
+  block:
+    - name: "Arch Linux | Validate OpenSSH daemon configuration before restart"
+      ansible.builtin.command:
+        cmd: sshd -t
+      register: _system_update_arch_sshd_validate
+      changed_when: false
+      failed_when: _system_update_arch_sshd_validate.rc != 0
+
+    - name: "Arch Linux | Restart OpenSSH daemon after package upgrade"
+      ansible.builtin.systemd_service:
+        name: sshd.service
+        state: restarted
+      register: _system_update_arch_sshd_restart
+
+    - name: "Arch Linux | Verify OpenSSH daemon is active after restart"
+      ansible.builtin.command:
+        cmd: systemctl is-active sshd.service
+      register: _system_update_arch_sshd_active
+      changed_when: false
+      failed_when: _system_update_arch_sshd_active.stdout | trim != 'active'


### PR DESCRIPTION
## Summary
- capture openssh package version before and after Arch full upgrade
- validate sshd config and restart sshd only when openssh changed
- assert backend ordering in molecule source checks

## Verification
- git diff --cached --check before commit