### PR TITLE
fix(hostctl): read virtualization type from facts

### DIFF
--- a/ansible/roles/hostctl/tasks/profiles/configure.yml
+++ b/ansible/roles/hostctl/tasks/profiles/configure.yml
@@ -18,5 +18,5 @@
     owner: root
     group: root
     mode: '0644'
-    unsafe_writes: "{{ ansible_virtualization_type | default('') == 'docker' }}"
+    unsafe_writes: "{{ ansible_facts['virtualization_type'] | default('') == 'docker' }}"
   tags: ['hostctl', 'hostctl:profiles']


### PR DESCRIPTION
## Summary
- use ansible_facts virtualization_type for Docker unsafe_writes detection

## Verification
- git diff --cached --check before commit