### PR TITLE
fix(chezmoi): repair user XDG ownership before apply

### DIFF
--- a/ansible/roles/chezmoi/README.md
+++ b/ansible/roles/chezmoi/README.md
@@ -9,9 +9,10 @@ install, download, or select a chezmoi version.
 ## Execution flow
 
 1. **Detect** (`tasks/detect/main.yml`) - resolves the existing `target_user` account.
-2. **Configure** (`tasks/configure/main.yml`) - clones the dotfiles repository
-   and creates the chezmoi config on first use, sets the selected theme, and
-   applies the desired state.
+2. **Configure** (`tasks/configure/main.yml`) - repairs the target user's scoped
+   XDG directory ownership, clones the dotfiles repository and creates the
+   chezmoi config on first use, sets the selected theme, and applies the desired
+   state.
 3. **Report** (`tasks/main.yml`) - records the user, source, and theme.
 
 There is no init-system logic, service management, handlers, or role-level
@@ -50,6 +51,14 @@ The dotfiles repository owns the resulting user files, including wallpapers
 under `~/.local/share/wallpapers/`. Chezmoi applies executable helpers,
 desktop configuration, and shell configuration.
 
+Before initializing or applying chezmoi, the role ensures `~/.local`,
+`~/.local/bin`, and `~/.local/share` are owned by `target_user`. The apply step
+runs with an explicit `umask 022` and `--parent-dirs` so target permissions
+match the source tree synchronized by chezmoi (`0644` files and `0755`
+chezmoi-managed directories). `~/.local/share` is kept at `0750`. This is
+intentionally scoped to the directories the role writes through, not a recursive
+ownership reset of the whole home directory.
+
 The layout-constants script uses chezmoi's `run_onchange_after` attribute. It
 runs on first apply and when its rendered layout/theme input changes, rather
 than rewriting the generated file on every role run.
@@ -57,8 +66,8 @@ than rewriting the generated file on every role run.
 On the first run, `chezmoi init <repo-url>` clones the source into the user's
 default chezmoi source directory and generates
 `~/.config/chezmoi/chezmoi.toml`. Every run then sets the requested theme and
-runs `chezmoi apply --verbose`. The apply task reports `changed` only when
-chezmoi reports applied file changes.
+runs `chezmoi apply --verbose --parent-dirs`. The apply task reports `changed`
+only when chezmoi reports applied file changes.
 
 ## Platform boundary
 
@@ -77,6 +86,8 @@ and idempotence.
   point `chezmoi_repo_url` at it with a `file://` URL, and verify that its
   neutral marker is deployed to the target user's home. The tests need no
   network access.
+- Shared tests first create root-owned `~/.local` directories and then verify
+  the role repairs their ownership before running chezmoi as the user.
 - Docker checks the contract in a container; Vagrant checks the same contract
   with a normal VM user and filesystem.
 
@@ -93,5 +104,6 @@ CI.
 | Chezmoi binary is missing | The `packages` role did not provide chezmoi | Inspect the package stage before running this role. |
 | Source cannot be cloned | `chezmoi_repo_url` is unreachable from the target | Check network access and the repository URL; do not add a second source variable to the role. |
 | Target account is missing | `target_user` does not identify an existing user | Create the account in the `user` role before this role runs. |
+| `chezmoi apply` cannot rename into `~/.local/bin` | A prior privileged task created user XDG directories as root | Rerun the role; it repairs scoped XDG directory ownership before applying dotfiles. |
 | Template rendering fails | Source data and templates are inconsistent | Fix the source template or data reported by chezmoi, then rerun the role. |
 | Theme does not change | Value is not one of the choices in `.chezmoi.toml.tmpl` | Use `dracula` or `monochrome`, or update the source template and role documentation together. |

--- a/ansible/roles/chezmoi/molecule/shared/prepare.yml
+++ b/ansible/roles/chezmoi/molecule/shared/prepare.yml
@@ -44,6 +44,18 @@
         create_home: true
         shell: /bin/bash
 
+    - name: Reproduce root-owned user XDG directories from prior system tasks
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      loop:
+        - /home/testuser/.local
+        - /home/testuser/.local/bin
+        - /home/testuser/.local/share
+
     - name: Create test source directory
       ansible.builtin.file:
         path: /opt/dotfiles

--- a/ansible/roles/chezmoi/molecule/shared/verify.yml
+++ b/ansible/roles/chezmoi/molecule/shared/verify.yml
@@ -9,9 +9,29 @@
         src: /home/testuser/.chezmoi_test_marker
       register: _chezmoi_test_marker
 
+    - name: Inspect repaired user XDG directories
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop:
+        - path: /home/testuser/.local
+          mode: "0755"
+        - path: /home/testuser/.local/bin
+          mode: "0755"
+        - path: /home/testuser/.local/share
+          mode: "0750"
+      register: _chezmoi_xdg_dirs
+
     - name: Require deployed source content
       ansible.builtin.assert:
         that:
           - >-
             _chezmoi_test_marker.content | b64decode
             == "chezmoi-deployment-test\n"
+
+    - name: Require target user ownership for XDG directories
+      ansible.builtin.assert:
+        that:
+          - item.stat.pw_name == "testuser"
+          - item.stat.gr_name == "testuser"
+          - item.stat.mode == item.item.mode
+      loop: "{{ _chezmoi_xdg_dirs.results }}"

--- a/ansible/roles/chezmoi/tasks/configure/main.yml
+++ b/ansible/roles/chezmoi/tasks/configure/main.yml
@@ -1,4 +1,21 @@
 ---
+- name: Resolve target user home directory
+  ansible.builtin.set_fact:
+    _chezmoi_target_home: "{{ ansible_facts['getent_passwd'][target_user][4] }}"
+
+- name: Ensure user XDG directories are writable by target user
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: directory
+    owner: "{{ target_user }}"
+    group: "{{ target_user }}"
+    mode: "{{ item.mode | default(omit) }}"
+  loop:
+    - path: "{{ _chezmoi_target_home }}/.local"
+    - path: "{{ _chezmoi_target_home }}/.local/bin"
+    - path: "{{ _chezmoi_target_home }}/.local/share"
+      mode: "0750"
+
 - name: Initialize chezmoi configuration
   become: true
   become_user: "{{ target_user }}"
@@ -10,14 +27,14 @@
         + (['--branch', chezmoi_repo_ref] if chezmoi_repo_ref | length > 0 else [])
         + [chezmoi_repo_url]
       }}
-    chdir: "{{ getent_passwd[target_user][4] }}"
-    creates: "{{ getent_passwd[target_user][4] }}/.config/chezmoi/chezmoi.toml"
+    chdir: "{{ _chezmoi_target_home }}"
+    creates: "{{ _chezmoi_target_home }}/.config/chezmoi/chezmoi.toml"
 
 - name: Configure dotfiles theme
   become: true
   become_user: "{{ target_user }}"
   ansible.builtin.lineinfile:
-    path: "{{ getent_passwd[target_user][4] }}/.config/chezmoi/chezmoi.toml"
+    path: "{{ _chezmoi_target_home }}/.config/chezmoi/chezmoi.toml"
     regexp: '^\s*theme_name\s*='
     line: '  theme_name = "{{ chezmoi_theme_name }}"'
     insertafter: '^\[data\]$'
@@ -27,11 +44,11 @@
   become_user: "{{ target_user }}"
   ansible.builtin.command:
     argv:
-      - /usr/bin/chezmoi
-      - --force
-      - --no-tty
-      - --verbose
-      - apply
-    chdir: "{{ getent_passwd[target_user][4] }}"
+      - /usr/bin/bash
+      - -lc
+      - |
+        umask 022
+        exec /usr/bin/chezmoi --force --no-tty --verbose apply --parent-dirs
+    chdir: "{{ _chezmoi_target_home }}"
   register: _chezmoi_apply
   changed_when: _chezmoi_apply.stdout | trim | length > 0


### PR DESCRIPTION
## Summary
- repair target-user ownership for scoped ~/.local directories before chezmoi init/apply
- keep standalone dotfiles repository flow intact
- run chezmoi apply with umask 022 and --parent-dirs
- add molecule coverage for root-owned XDG directory repair

## Verification
- git diff --cached --check before commit