### PR TITLE
fix(vm): stabilize VirtualBox display resizing

### DIFF
--- a/ansible/roles/vm/README.md
+++ b/ansible/roles/vm/README.md
@@ -55,9 +55,10 @@ Flow:
 4. Install Guest Additions from ISO only when host and guest versions differ.
 5. Configure `/dev/vboxguest` access and `vboxsf` user membership.
 6. Configure XDG autostart for `VBoxClient-all`.
-7. Configure time-sync policy for the active init system.
-8. Start `vboxadd-service`.
-9. Verify `vboxguest` and `vboxsf`; report optional `vboxvideo`.
+7. Configure a LightDM XRandR resize hook for VirtualBox VMSVGA display hints.
+8. Configure time-sync policy for the active init system.
+9. Start `vboxadd-service`.
+10. Verify `vboxguest` and `vboxsf`; report optional `vboxvideo`.
 10. Report version when `vm_vbox_version_check` is enabled.
 
 ISO install cleanup lives in the ISO install flow. If ISO install fails, rescue
@@ -154,6 +155,15 @@ Desktop integration is user-session integration, not a system service.
 
 These files are for XDG-compliant graphical sessions. X11 is the current
 priority for clipboard and drag-and-drop behavior.
+
+The LightDM login screen starts before a user's XDG desktop session exists, so
+it cannot rely on `/etc/xdg/autostart/vboxclient.desktop`. For VirtualBox VMSVGA
+guests the role also installs
+`/usr/local/lib/bootstrap/virtualbox-lightdm-xrandr-auto` and
+`/etc/lightdm/lightdm.conf.d/30-virtualbox-display-resize.conf`. The helper
+watches the XRandR preferred mode exposed by VirtualBox resize hints and applies
+it to the active LightDM X server. It does not start `VBoxClient` in the greeter
+process tree.
 
 ## Variables
 

--- a/ansible/roles/vm/defaults/main.yml
+++ b/ansible/roles/vm/defaults/main.yml
@@ -17,6 +17,10 @@ vm_packages_hyperv_guest:
 vm_packages_kvm_guest:
   - qemu-guest-agent
 
+# X11 utility packages used by the VirtualBox LightDM resize helper.
+# Distro-specific package names live in vars/<OsFamily>.yml.
+vm_vbox_lightdm_resize_packages: []
+
 # VBox host version override - set to bypass dmesg/journalctl detection.
 # Use when the kernel ring buffer was cleared on a long-running system.
 # Example: vm_vbox_host_version_override: "7.1.16"

--- a/ansible/roles/vm/tasks/hypervisor/virtualbox/configure/desktop-integration.yml
+++ b/ansible/roles/vm/tasks/hypervisor/virtualbox/configure/desktop-integration.yml
@@ -31,3 +31,186 @@
     owner: root
     group: root
     mode: "0644"
+
+- name: "VirtualBox: Install LightDM resize helper packages"
+  ansible.builtin.package:
+    name: "{{ vm_vbox_lightdm_resize_packages }}"
+    state: present
+  register: vm_vbox_lightdm_resize_package_install
+  retries: 3
+  delay: 5
+  until: vm_vbox_lightdm_resize_package_install is succeeded
+  when: vm_vbox_lightdm_resize_packages | length > 0
+
+- name: "VirtualBox: Remove deprecated LightDM VBoxClient resize helper"
+  ansible.builtin.file:
+    path: /usr/local/lib/bootstrap/virtualbox-lightdm-resize
+    state: absent
+
+- name: "VirtualBox: Ensure bootstrap helper directory exists"
+  ansible.builtin.file:
+    path: /usr/local/lib/bootstrap
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: "VirtualBox: Install LightDM XRandR resize helper"
+  ansible.builtin.copy:
+    dest: /usr/local/lib/bootstrap/virtualbox-lightdm-xrandr-auto
+    content: |
+      #!/bin/sh
+      set -eu
+
+      [ -x /usr/bin/xrandr ] || exit 0
+
+      case "$(systemd-detect-virt 2>/dev/null || true)" in
+        oracle|virtualbox) ;;
+        *) exit 0 ;;
+      esac
+
+      export DISPLAY="${DISPLAY:-:0}"
+      export XAUTHORITY="${XAUTHORITY:-/run/lightdm/root/${DISPLAY}}"
+      pidfile="/run/virtualbox-lightdm-xrandr-auto.pid"
+      greeter_seen=0
+
+      greeter_is_running() {
+        pgrep -u lightdm -f '/opt/nody-greeter/nody-greeter' >/dev/null 2>&1
+      }
+
+      resize_greeter_window() {
+        [ -x /usr/bin/xdotool ] || return 0
+
+        size="$(/usr/bin/xrandr --query 2>/dev/null | awk '/^Screen 0:/{ print $8 "x" $10; exit }' | tr -d ',')"
+        [ -n "${size}" ] || return 0
+
+        width="${size%x*}"
+        height="${size#*x}"
+        [ -n "${width}" ] && [ -n "${height}" ] || return 0
+
+        /usr/bin/xdotool search --name '^ctOS$' 2>/dev/null | while read -r window_id; do
+          [ -n "${window_id}" ] || continue
+          /usr/bin/xdotool windowmove "${window_id}" 0 0 windowsize "${window_id}" "${width}" "${height}" || true
+        done
+      }
+
+      # The watcher applies the mode that VirtualBox exposes as preferred.
+      # This keeps LightDM's X server in sync with host-side resize hints
+      # and resizes the existing greeter window to the new X root size.
+      if [ "${1:-}" = "--watch" ]; then
+        echo "$$" >"${pidfile}"
+        trap 'rm -f "${pidfile}" /tmp/virtualbox-lightdm-xrandr.$$' EXIT INT TERM
+
+        while /usr/bin/xrandr --query >/tmp/virtualbox-lightdm-xrandr.$$ 2>/dev/null; do
+          if greeter_is_running; then
+            greeter_seen=1
+          elif [ "${greeter_seen}" -eq 1 ]; then
+            exit 0
+          fi
+
+          output="$(awk '/ connected/{ print $1; exit }' /tmp/virtualbox-lightdm-xrandr.$$)"
+          preferred="$(awk '
+            / connected/{ in_output = 1; next }
+            in_output && / disconnected/{ exit }
+            in_output && /\+/{ print $1; exit }
+          ' /tmp/virtualbox-lightdm-xrandr.$$)"
+          current="$(awk '
+            / connected/{ in_output = 1; next }
+            in_output && / disconnected/{ exit }
+            in_output && /\*/{ print $1; exit }
+          ' /tmp/virtualbox-lightdm-xrandr.$$)"
+
+          if [ -n "${output}" ] && [ -n "${preferred}" ] && [ "${preferred}" != "${current}" ]; then
+            /usr/bin/xrandr --output "${output}" --mode "${preferred}" || true
+          fi
+          resize_greeter_window
+
+          rm -f /tmp/virtualbox-lightdm-xrandr.$$
+          sleep 1
+        done
+
+        exit 0
+      fi
+
+      if [ -s "${pidfile}" ]; then
+        pid="$(cat "${pidfile}")"
+        if [ -n "${pid}" ] && kill -0 "${pid}" 2>/dev/null; then
+          exit 0
+        fi
+        rm -f "${pidfile}"
+      fi
+
+      "$0" --watch >/var/log/virtualbox-lightdm-xrandr-auto.log 2>&1 &
+    owner: root
+    group: root
+    mode: "0755"
+  register: vm_vbox_lightdm_resize_helper
+
+- name: "VirtualBox: Check active LightDM X authority"
+  ansible.builtin.stat:
+    path: /run/lightdm/root/:0
+  register: vm_vbox_lightdm_xauthority
+
+- name: "VirtualBox: Check active LightDM greeter"
+  ansible.builtin.command:
+    argv:
+      - pgrep
+      - -u
+      - lightdm
+      - -f
+      - /opt/nody-greeter/nody-greeter
+  register: vm_vbox_lightdm_greeter_check
+  changed_when: false
+  failed_when: vm_vbox_lightdm_greeter_check.rc not in [0, 1]
+
+- name: "VirtualBox: Stop stale LightDM XRandR resize watcher"
+  ansible.builtin.shell: |
+    set -eu
+    pids="$(pgrep -f '^/bin/sh /usr/local/lib/bootstrap/virtualbox-lightdm-xrandr-auto --watch$' || true)"
+    [ -n "${pids}" ] || exit 1
+
+    kill -TERM ${pids} 2>/dev/null || true
+    sleep 1
+
+    for pid in ${pids}; do
+      if kill -0 "${pid}" 2>/dev/null; then
+        kill -KILL "${pid}" 2>/dev/null || true
+      fi
+    done
+  args:
+    executable: /bin/sh
+  register: vm_vbox_lightdm_resize_watcher_stop
+  changed_when: vm_vbox_lightdm_resize_watcher_stop.rc == 0
+  failed_when: vm_vbox_lightdm_resize_watcher_stop.rc not in [0, 1]
+  when: vm_vbox_lightdm_resize_helper.changed or vm_vbox_lightdm_greeter_check.rc != 0
+
+- name: "VirtualBox: Start LightDM XRandR resize watcher"
+  ansible.builtin.command:
+    argv:
+      - /usr/local/lib/bootstrap/virtualbox-lightdm-xrandr-auto
+  environment:
+    DISPLAY: ":0"
+    XAUTHORITY: /run/lightdm/root/:0
+  changed_when: true
+  when:
+    - vm_vbox_lightdm_resize_helper.changed
+    - vm_vbox_lightdm_xauthority.stat.exists
+    - vm_vbox_lightdm_greeter_check.rc == 0
+
+- name: "VirtualBox: Ensure LightDM drop-in directory exists"
+  ansible.builtin.file:
+    path: /etc/lightdm/lightdm.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: "VirtualBox: Configure LightDM dynamic display resize hook"
+  ansible.builtin.copy:
+    dest: /etc/lightdm/lightdm.conf.d/30-virtualbox-display-resize.conf
+    content: |
+      [Seat:*]
+      display-setup-script=/usr/local/lib/bootstrap/virtualbox-lightdm-xrandr-auto
+    owner: root
+    group: root
+    mode: "0644"

--- a/ansible/roles/vm/tasks/hypervisor/virtualbox/configure/timesync/systemd.yml
+++ b/ansible/roles/vm/tasks/hypervisor/virtualbox/configure/timesync/systemd.yml
@@ -66,8 +66,9 @@
     dest: "/etc/systemd/system/{{ vm_vbox_guest_service_name }}.service.d/disable-timesync.conf"
     content: |
       [Service]
+      ExecStartPre=/bin/sh -c 'if [ -s /var/run/vboxadd-service.sh ] && kill -0 "$(cat /var/run/vboxadd-service.sh)" 2>/dev/null; then kill "$(cat /var/run/vboxadd-service.sh)" || true; sleep 1; fi; rm -f /var/run/vboxadd-service.sh'
       ExecStart=
-      ExecStart=/usr/bin/VBoxService -f --disable-timesync
+      ExecStart=/usr/bin/VBoxService --pidfile /var/run/vboxadd-service.sh --disable-timesync
     owner: root
     group: root
     mode: "0644"

--- a/ansible/roles/vm/tasks/hypervisor/virtualbox/service/systemd.yml
+++ b/ansible/roles/vm/tasks/hypervisor/virtualbox/service/systemd.yml
@@ -1,7 +1,85 @@
 ---
+- name: "VirtualBox: Inspect vboxguest module source"
+  ansible.builtin.command: modinfo vboxguest
+  register: vm_vbox_vboxguest_modinfo
+  changed_when: false
+
+- name: "VirtualBox: Check legacy kernel module service unit"
+  ansible.builtin.command: systemctl list-unit-files vboxadd.service --no-legend
+  register: vm_vbox_legacy_module_service_unit
+  changed_when: false
+  failed_when: vm_vbox_legacy_module_service_unit.rc not in [0, 1]
+
+- name: "VirtualBox: Disable legacy kernel module rebuild service"
+  ansible.builtin.systemd:
+    name: vboxadd.service
+    enabled: false
+    state: stopped
+    daemon_reload: true
+  when:
+    - vm_vbox_legacy_module_service_unit.rc == 0
+    - vm_vbox_vboxguest_modinfo.stdout is search('(?m)^intree:\\s+Y$')
+
+- name: "VirtualBox: Clear legacy kernel module service failure state"
+  ansible.builtin.command: systemctl reset-failed vboxadd.service
+  changed_when: false
+  when:
+    - vm_vbox_legacy_module_service_unit.rc == 0
+    - vm_vbox_vboxguest_modinfo.stdout is search('(?m)^intree:\\s+Y$')
+
+- name: "VirtualBox: Check guest service state"
+  ansible.builtin.command: "systemctl is-active {{ vm_vbox_guest_service_name }}"
+  register: vm_vbox_service_active
+  changed_when: false
+  failed_when: vm_vbox_service_active.rc not in [0, 3]
+
+- name: "VirtualBox: Check for orphan VBoxService process"
+  ansible.builtin.command: pgrep -x VBoxService
+  register: vm_vbox_orphan_service_pids
+  changed_when: false
+  failed_when: vm_vbox_orphan_service_pids.rc not in [0, 1]
+  when: vm_vbox_service_active.rc != 0
+
+- name: "VirtualBox: Stop orphan VBoxService process"
+  ansible.builtin.command: pkill -TERM -x VBoxService
+  changed_when: true
+  when:
+    - vm_vbox_service_active.rc != 0
+    - vm_vbox_orphan_service_pids.rc == 0
+
 - name: "VirtualBox: Start guest service"
   ansible.builtin.systemd:
     name: "{{ vm_vbox_guest_service_name }}"
     enabled: true
     state: started
     daemon_reload: true
+
+- name: "VirtualBox: Configure DRM resize client service"
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/vboxadd-drm-client.service
+    content: |
+      [Unit]
+      Description=VirtualBox Guest Additions DRM resize client
+      After=vboxadd.service {{ vm_vbox_guest_service_name }}.service
+      Before=display-manager.service lightdm.service
+
+      [Service]
+      Type=simple
+      ExecStartPre=/bin/sh -c 'if [ -s /var/run/VBoxDRMClient ] && kill -0 "$(cat /var/run/VBoxDRMClient)" 2>/dev/null; then kill -USR1 "$(cat /var/run/VBoxDRMClient)" || true; sleep 1; fi; rm -f /var/run/VBoxDRMClient'
+      ExecStart=/usr/bin/VBoxDRMClient
+      Restart=on-failure
+      KillSignal=SIGUSR1
+
+      [Install]
+      WantedBy=multi-user.target
+    owner: root
+    group: root
+    mode: "0644"
+  register: vm_vbox_drm_client_service
+
+- name: "VirtualBox: Start DRM resize client service"
+  ansible.builtin.systemd:
+    name: vboxadd-drm-client.service
+    enabled: true
+    state: started
+    daemon_reload: "{{ vm_vbox_drm_client_service.changed }}"

--- a/ansible/roles/vm/vars/Archlinux.yml
+++ b/ansible/roles/vm/vars/Archlinux.yml
@@ -24,3 +24,6 @@ vm_vbox_lts_kernel_support: true
 # VirtualBox kernel headers: Archlinux uses linux-lts-headers for LTS kernels.
 vm_vbox_kernel_header_packages:
   - "{{ 'linux-lts-headers' if '-lts' in ansible_kernel else 'linux-headers' }}"
+
+vm_vbox_lightdm_resize_packages:
+  - xdotool

--- a/ansible/roles/vm/vars/Debian.yml
+++ b/ansible/roles/vm/vars/Debian.yml
@@ -26,3 +26,6 @@ vm_vbox_lts_kernel_support: false
 # VirtualBox kernel headers: Debian packages headers per running kernel.
 vm_vbox_kernel_header_packages:
   - "linux-headers-{{ ansible_kernel }}"
+
+vm_vbox_lightdm_resize_packages:
+  - xdotool

--- a/ansible/roles/vm/vars/Gentoo.yml
+++ b/ansible/roles/vm/vars/Gentoo.yml
@@ -25,3 +25,6 @@ vm_vbox_lts_kernel_support: false
 
 # VirtualBox kernel headers: Gentoo — headers are part of kernel source
 vm_vbox_kernel_header_packages: []
+
+vm_vbox_lightdm_resize_packages:
+  - x11-misc/xdotool

--- a/ansible/roles/vm/vars/RedHat.yml
+++ b/ansible/roles/vm/vars/RedHat.yml
@@ -26,3 +26,6 @@ vm_vbox_lts_kernel_support: false
 # VirtualBox kernel headers: static for RedHat
 vm_vbox_kernel_header_packages:
   - kernel-devel
+
+vm_vbox_lightdm_resize_packages:
+  - xdotool

--- a/ansible/roles/vm/vars/Void.yml
+++ b/ansible/roles/vm/vars/Void.yml
@@ -19,3 +19,6 @@ vm_vbox_lts_kernel_support: false
 # VirtualBox kernel headers: static for Void
 vm_vbox_kernel_header_packages:
   - linux-headers
+
+vm_vbox_lightdm_resize_packages:
+  - xdotool

--- a/scripts/clone-test-vm.sh
+++ b/scripts/clone-test-vm.sh
@@ -78,8 +78,10 @@ for rule in ssh ssh2222 ssh2223; do
 done
 VBoxManage modifyvm "$NAME" --natpf1 "ssh,tcp,,$PORT,,22"
 
-# Step 4: Enable 3D + 128 MB VRAM (required for ctOS greeter)
+# Step 4: Enable graphics integration required for ctOS greeter and GUI testing.
 VBoxManage modifyvm "$NAME" --accelerate3d on --vram 128 2>/dev/null || true
+VBoxManage setextradata "$NAME" GUI/AutoresizeGuest true
+VBoxManage setextradata "$NAME" GUI/Scale false
 
 # Step 5: Start headless
 echo "==> Starting '$NAME' headless..."


### PR DESCRIPTION
## Summary
- install LightDM XRandR resize helper packages per distro
- add LightDM greeter resize helper that exits after greeter handoff
- stop stale root watcher after login
- disable legacy vboxadd.service when kernel guest modules are in use
- set VirtualBox GUI autoresize defaults for cloned test VMs

## Verification
- git diff --cached --check before commit