### PR TITLE
config: set workstation desktop inventory defaults

### DIFF
--- a/ansible/inventory/group_vars/all/system.yml
+++ b/ansible/inventory/group_vars/all/system.yml
@@ -35,7 +35,7 @@ hostname_name: "archbox"
 
 hostctl_hosts_entries:
   - ip: "127.0.0.1"
-    hosts: ["localhost"]
+    hosts: ["localhost", "vault.local"]
   - ip: "127.0.1.1"
     hosts: ["archbox"]
 
@@ -78,6 +78,12 @@ ssh_keys_authorized_keys: []
 ssh_keys_exclusive: false
 ssh_keys_generate_user_key: true
 ssh_keys_user_key_type: ed25519
+
+# ============================================================
+#  chezmoi — роль roles/chezmoi
+# ============================================================
+
+chezmoi_theme_name: "monochrome"
 
 # ============================================================
 #  git — роль roles/git


### PR DESCRIPTION
## Summary
- map vault.local through hostctl inventory
- select monochrome chezmoi theme by workstation inventory
- intentionally leave ssh_keys_authorized_keys empty; VM access keys are local test data, not project defaults

## Verification
- git diff --cached --check before commit