### PR TITLE
chore: ignore rust target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ node_modules/
 # ---- Build artifacts ----
 dist/
 build/
+target/
 *.egg-info/
 
 # ---- Archives ----


### PR DESCRIPTION
## Summary
- ignore Rust/Cargo target/ build output

## Verification
- git diff --cached --check before commit